### PR TITLE
Stack-safe versions of BitVector functions and tests

### DIFF
--- a/src/test/scala/scodec/bits/BitVectorTest.scala
+++ b/src/test/scala/scodec/bits/BitVectorTest.scala
@@ -69,8 +69,11 @@ class BitVectorTest extends FunSuite with Matchers with GeneratorDrivenPropertyC
     }
   }
 
-  test("compact stack safety") {
-    forAll (hugeBitStreams) { b => b.compact shouldBe b }
+  test("compact/force stack safety") {
+    forAll (hugeBitStreams) { b =>
+      b.force shouldBe b
+      b.compact shouldBe b
+    }
   }
 
   test("hashCode/equals/take/drop stack safety") {


### PR DESCRIPTION
The functions `compact`, `force`, `take`, `drop`, and `sizeLess/GreaterThan` are all tail recursive. Added a deeply right recursive stream generator and tests for stack safety. Also did an audit of the other functions on `BitVector`. The only ones I have left alone for now are `size` and `get`/`updated`, because these would require more substantive restructuring. Perhaps we can track that as a separate issue, if we decide we want to do those also.

I'm also not convinced that silently having linear time/space behavior is really better than just bombing with a SOE, esp given that these functions `fromInputStream`, etc, are rather unsafe and meant to be used when you Really Know What You're Doing (TM). Calling `size` on a large streaming bit vector is really just something you shouldn't be doing, nor should you be calling `get`/`updated` on some huge index. With this PR, the model is that access to the front of a lazy stream is fast, and if you want to work close to the end, you advance your way there via `drop`. This is better for memory usage as well, because it means you don't keep the head of the stream around.
