### PR TITLE
Make BitVector#sizeLessThan remember upper and lower bounds on size.

### DIFF
--- a/src/main/scala/scodec/bits/BitVector.scala
+++ b/src/main/scala/scodec/bits/BitVector.scala
@@ -86,8 +86,8 @@ sealed trait BitVector extends BitwiseOperations[BitVector, Long] {
   final def sizeLessThan(n: Long): Boolean = {
     @annotation.tailrec
     def go(b: BitVector, n: Long): Boolean = {
-      if (n < sizeLowerBound.get) false
-      else if (n > sizeUpperBound.get) true
+      if (n < b.sizeLowerBound.get) false
+      else if (n > b.sizeUpperBound.get) true
       else b match {
         case Append(l, r) =>
           if (n - l.sizeLowerBound.get < r.sizeLowerBound.get) false

--- a/src/test/scala/scodec/bits/BitVectorTest.scala
+++ b/src/test/scala/scodec/bits/BitVectorTest.scala
@@ -430,10 +430,12 @@ class BitVectorTest extends FunSuite with Matchers with GeneratorDrivenPropertyC
 
   test("sizeLessThan") { forAll { (x: BitVector) =>
     x.sizeLessThan(x.size+1) shouldBe true
+    x.sizeLessThan(x.size) shouldBe false
   }}
 
   test("sizeGreaterThan") { forAll { (x: BitVector) =>
     (0 until x.size.toInt).forall(i => x.sizeGreaterThan(i)) shouldBe true
+    x.sizeLessThan(x.size+1) shouldBe true
   }}
 
   test("sizeGreater/LessThan concurrent") { forAll { (x: BitVector) =>


### PR DESCRIPTION
This implementation only updates bounds on the top-level bit vector
that `sizeLessThan` is called on. I tested an implementation that
passes a bounds updating continuation to `go` but it performed worse
in the unit tests.

Also, note that `Append.size` makes the bounds tight for that node.
Further, `sizeLessThan` calls `size` on the left side of append
nodes, resulting in many tree nodes getting tight bounds anyway.

Review by @pchiusano 
