### PR TITLE
Make toByteBuffer method return a read only representation which 'may' avoid a copy

### DIFF
--- a/src/test/scala/scodec/bits/ByteVectorTest.scala
+++ b/src/test/scala/scodec/bits/ByteVectorTest.scala
@@ -233,6 +233,14 @@ class ByteVectorTest extends BitsSuite {
     }
   }
 
+  test("toByteBuffer roundtrip") {
+    forAll { (b: ByteVector) =>
+      val fromBuffer = ByteVector(b.toByteBuffer)
+      b shouldBe fromBuffer
+      fromBuffer shouldBe b
+    }
+  }
+
   test("dropping from a view is consistent with dropping from a strict vector") {
     forAll { (b: ByteVector, n0: Int) =>
       val view = ByteVector.view(b.toArray)


### PR DESCRIPTION
In ref to issue #12
ByteVectors generated from a `ByteBuffer` or an `Array[Byte]` will avoid copying the underlying structure when calling `toByteBuffer`.

Note: to keep the underlying data structure immutable and avoid making a copy, the returned ByteBuffer is now read-only.
