### PR TITLE
Introduce viewRange with explicit offset/size for Array[Byte]

### DIFF
--- a/src/main/scala/scodec/bits/ByteVector.scala
+++ b/src/main/scala/scodec/bits/ByteVector.scala
@@ -963,9 +963,15 @@ object ByteVector {
    * @group constructors
    */
   def view(bytes: Array[Byte]): ByteVector =
-    Chunk(View(AtArray(bytes), 0, bytes.length))
+    viewRange(bytes, 0, bytes.length)
 
   /**
+   * @see view(Array[Byte])
+   */
+  def viewRange(bytes: Array[Byte], offset: Int, size: Int): ByteVector =
+    Chunk(View(AtArray(bytes), offset, size))
+
+   /**
    * Constructs a `ByteVector` from a `ByteBuffer`. Unlike `apply`, this
    * does not make a copy of the input buffer, so callers should take care
    * not to modify the contents of the buffer passed to this function.


### PR DESCRIPTION
We have a desire to pass around ranges for Arrays, but there doesn't appear to be a way to do this via the public api.

I actually think there might be a better, more generic way of doing this (so we get this for all the other `view` variants for free). For example returning the `view` type directly on those methods, and having a `toChunk` method when the view manipulation has been done. Or something like that.

Alternatively we could add named arguments with defaults, but that is generally a Bad Idea in Scala, at least in my experience.

I'm more than happy to make some of these changes if I know what might be considered OK/safe, as I'm assuming there might be a good reason it hasn't been done yet. Thanks in advance for suggestions.
