### PR TITLE
Initial cut at converting ByteVector to Long indexes.

### DIFF
--- a/src/main/scala/scodec/bits/BitVector.scala
+++ b/src/main/scala/scodec/bits/BitVector.scala
@@ -889,7 +889,7 @@ sealed trait BitVector extends BitwiseOperations[BitVector, Long] with Serializa
   /**
    * Computes a digest of this bit vector.
    * The last byte is zero padded if the size is not evenly divisible by 8.
-   * @param algoritm digest algorithm to use
+   * @param algorithm digest algorithm to use
    * @group conversions
    */
   final def digest(algorithm: String): BitVector = digest(MessageDigest.getInstance(algorithm))
@@ -1116,7 +1116,7 @@ object BitVector {
   def view(buffer: ByteBuffer, sizeInBits: Long): BitVector = {
     require(bytesNeededForBits(sizeInBits) <= Int.MaxValue,
       "Cannot have BitVector chunk larger than Int.MaxValue bytes: " + sizeInBits)
-    toBytes(ByteVector.view(ind => buffer.get(ind), bytesNeededForBits(sizeInBits).toInt), sizeInBits)
+    toBytes(ByteVector.view(ind => buffer.get(ind.toInt), bytesNeededForBits(sizeInBits).toInt), sizeInBits)
   }
 
   /**
@@ -1166,7 +1166,7 @@ object BitVector {
 
   /**
    * Constructs a bit vector with the 2's complement encoding of the specified value.
-   * @param i value to encode
+   * @param l value to encode
    * @param size size of vector (<= 64)
    * @param ordering byte ordering of vector
    */
@@ -1292,7 +1292,7 @@ object BitVector {
   /**
    * Produce a lazy `BitVector` from the given `InputStream`, using `chunkSizeInBytes`
    * to control the number of bytes read in each chunk (defaulting to 4MB).
-   * This simply calls [[scodec.BitVector.unfold]] with a function to extract a series
+   * This simply calls [[scodec.bits.BitVector.unfold]] with a function to extract a series
    * of flat byte arrays from the `InputStream`.
    *
    * This function does not handle closing the `InputStream` and has all the usual
@@ -1317,7 +1317,7 @@ object BitVector {
   /**
    * Produce a lazy `BitVector` from the given `ReadableByteChannel`, using `chunkSizeInBytes`
    * to control the number of bytes read in each chunk (defaulting to 8k). This function
-   * does lazy I/O, see [[scodec.BitVector.fromInputStream]] for caveats. The `direct`
+   * does lazy I/O, see [[scodec.bits.BitVector.fromInputStream]] for caveats. The `direct`
    * parameter, if `true`, allows for (but does not enforce) using a 'direct' [[java.nio.ByteBuffer]]
    * for each chunk, which means the buffer and corresponding `BitVector` chunk may be backed by a
    * 'view' rather than an in-memory array. This may be more efficient for some workloads. See
@@ -1341,7 +1341,7 @@ object BitVector {
   /**
    * Produce a lazy `BitVector` from the given `FileChannel`, using `chunkSizeInBytes`
    * to control the number of bytes read in each chunk (defaulting to 16MB). Unlike
-   * [[scodec.BitVector.fromChannel]], this memory-maps chunks in, rather than copying
+   * [[scodec.bits.BitVector.fromChannel]], this memory-maps chunks in, rather than copying
    * them explicitly.
    *
    * Behavior is unspecified if this function is used concurrently with the underlying

--- a/src/test/scala/scodec/bits/ByteVectorTest.scala
+++ b/src/test/scala/scodec/bits/ByteVectorTest.scala
@@ -20,7 +20,7 @@ class ByteVectorTest extends BitsSuite {
 
   def genSplit(g: Gen[ByteVector]) = for {
     b <- g
-    n <- Gen.choose(0, b.size+1)
+    n <- Gen.choose(0L, b.size+1)
   } yield {
     b.take(n) ++ b.drop(n)
   }
@@ -43,7 +43,7 @@ class ByteVectorTest extends BitsSuite {
 
   val bytesWithIndex = for {
     b <- byteVectors
-    i <- Gen.choose(0, b.size+1)
+    i <- Gen.choose(0L, b.size+1)
   } yield (b, i)
 
   implicit val arbitraryByteVectors: Arbitrary[ByteVector] = Arbitrary(byteVectors)
@@ -92,12 +92,13 @@ class ByteVectorTest extends BitsSuite {
 
   test("consistent with Array[Byte] implementations") {
     forAll (bytesWithIndex) { case (b, ind) =>
+      val indI = ind.toInt
       val ba = b.toArray
-      b.take(ind).toArray shouldBe ba.take(ind)
-      b.drop(ind).toArray shouldBe ba.drop(ind)
-      b.lift(ind) shouldBe ba.lift(ind)
-      b.takeRight(ind).toArray shouldBe ba.takeRight(ind)
-      b.dropRight(ind).toArray shouldBe ba.dropRight(ind)
+      b.take(ind).toArray shouldBe ba.take(indI)
+      b.drop(ind).toArray shouldBe ba.drop(indI)
+      b.lift(ind) shouldBe ba.lift(indI)
+      b.takeRight(ind).toArray shouldBe ba.takeRight(indI)
+      b.dropRight(ind).toArray shouldBe ba.dropRight(indI)
       b.reverse.toArray shouldBe ba.reverse
       b.partialCompact(ind).toArray shouldBe ba
       b.lastOption shouldBe ba.lastOption
@@ -108,7 +109,7 @@ class ByteVectorTest extends BitsSuite {
       }
       if (ind < b.size) {
         val actual = b.update(ind,9).toArray
-        val correct = Vector(b.toArray: _*).updated(ind,9).toArray
+        val correct = Vector(b.toArray: _*).updated(indI,9).toArray
         actual shouldBe correct
       }
 
@@ -181,7 +182,7 @@ class ByteVectorTest extends BitsSuite {
         a.foldLeft(acc)(_ :+ _)
       )
       unbuf shouldBe buf
-      (0 until unbuf.size).foreach { i => unbuf(i) shouldBe buf(i) }
+      (0L until unbuf.size).foreach { i => unbuf(i) shouldBe buf(i) }
     }}
   }
 
@@ -190,7 +191,7 @@ class ByteVectorTest extends BitsSuite {
       val unbuf = bs.foldLeft(b)(_ ++ _)
       val buf = bs.foldLeft(b.bufferBy((n % 50).max(0) + 1))(_ ++ _)
       unbuf shouldBe buf
-      (0 until unbuf.size).foreach { i => unbuf(i) shouldBe buf(i) }
+      (0L until unbuf.size).foreach { i => unbuf(i) shouldBe buf(i) }
       val ind = (n % (unbuf.size+1)).max(0) + 1
       buf.take(ind) shouldBe unbuf.take(ind)
       buf.drop(ind) shouldBe unbuf.drop(ind)
@@ -304,9 +305,9 @@ class ByteVectorTest extends BitsSuite {
       if (bv.isEmpty) {
         bv.grouped(1) shouldBe Stream.empty
       } else if (bv.size < 3) {
-        bv.grouped(bv.size) shouldBe Stream(bv)
+        bv.grouped(bv.size.toInt) shouldBe Stream(bv)
       } else {
-        bv.grouped(bv.size / 3).toList.foldLeft(ByteVector.empty) { (acc, b) => acc ++ b } shouldBe bv
+        bv.grouped(bv.size.toInt / 3).toList.foldLeft(ByteVector.empty) { (acc, b) => acc ++ b } shouldBe bv
       }
     }
   }


### PR DESCRIPTION
Minimal logic changes, would not actually work properly for vectors > Integer.MAX_VALUE in length.
