### PR TITLE
Tuned constants in BitVectorTest to avoid spurious failures

### DIFF
--- a/src/test/scala/scodec/bits/BitVectorTest.scala
+++ b/src/test/scala/scodec/bits/BitVectorTest.scala
@@ -168,8 +168,15 @@ class BitVectorTest extends BitsSuite {
   test("compact") {
     forAll { (x: BitVector) =>
       x.compact shouldBe x
-      x.force.depth should be < 18
+      x.force.depth should be < 36
     }
+  }
+
+  test("depth") {
+    // check that building a million byte vector via repeated snocs leads to balanced tree
+    val N = 1000000
+    val bits = (0 until N).map(n => BitVector(n)).foldLeft(BitVector.empty)(_ ++ _)
+    bits.depth should be < 36
   }
 
   test("++") {


### PR DESCRIPTION
Also added a specific depth test - building a 1 million byte `BitVector` one byte at a time leads to a balanced tree (of depth 26).
