### PR TITLE
Fixes #29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,5 @@
    - "2.11.6"
  jdk:
    - oraclejdk8
-   - openjdk8
 script:
   - sbt ++$TRAVIS_SCALA_VERSION test mima-report-binary-issues

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
    - "2.10.5"
    - "2.11.6"
  jdk:
-   - oraclejdk7
-   - openjdk7
+   - oraclejdk8
+   - openjdk8
 script:
   - sbt ++$TRAVIS_SCALA_VERSION test mima-report-binary-issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.0.8
+=====
+ - *Significant* performance improvement in `toBase64`.
+
 1.0.7
 =====
  - Improved performance of creating vectors from hex/bin.

--- a/benchmark/src/main/scala/ScodecBitsBenchmark.scala
+++ b/benchmark/src/main/scala/ScodecBitsBenchmark.scala
@@ -1,9 +1,12 @@
 package scodec.bits
 
-import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations.{ Benchmark, BenchmarkMode, Mode, OutputTimeUnit, Scope, State }
 import akka.util.ByteString
 
 @State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
 class ScodecBitsBenchmark {
 
   val N = 100000L
@@ -117,4 +120,9 @@ class ScodecBitsBenchmark {
     (M.toInt until 0 by -512).foldLeft(byteVector_M)((b,n) => b.take(n)).size
   @Benchmark def byteStringTake_M(): Int =
     (M.toInt until 0 by -512).foldLeft(byteString_M)((b,n) => b.take(n)).size
+
+  @Benchmark def toBase64(): String =
+    bitVector_M.toBase64
+  @Benchmark def toBase64_JRE(): String =
+    java.util.Base64.getEncoder.encodeToString(bitVector_M.toByteArray)
 }


### PR DESCRIPTION
From benchmark project:
```
> run -i 10 -wi 10 -f1 -t1 .*toBase64.*
...
[info] Benchmark                         Mode  Cnt   Score   Error  Units
[info] ScodecBitsBenchmark.toBase64      avgt   10  20.483 ± 2.738  us/op
[info] ScodecBitsBenchmark.toBase64_JRE  avgt   10   9.074 ± 0.533  us/op
```