### PR TITLE
Improve performance of numeric conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-1.0.8
+1.0.10
+======
+ - Improve performance of `toInt` and `fromInt`, `toLong` and `fromLong`, etc.
+
+1.0.9
 =====
  - *Significant* performance improvement in `toBase64`.
  - Fixed source links in ScalaDoc.

--- a/benchmark/src/main/scala/NumericConversionBenchmarks.scala
+++ b/benchmark/src/main/scala/NumericConversionBenchmarks.scala
@@ -1,0 +1,85 @@
+package scodec.bits
+
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations.{ Benchmark, BenchmarkMode, Mode, OutputTimeUnit, Scope, State }
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+class NumericConversionBenchmarks {
+
+  val N = 1024
+
+  def bitVectors(size: Int) = (0 to N).map { n => BitVector.fromLong(n.toLong).take(size.toLong).compact }
+
+  val bitVectors64bits = bitVectors(64)
+  val bitVectors60bits = bitVectors(60)
+  val bitVectors32bits = bitVectors(32)
+  val bitVectors32bitsNonCompacted = bitVectors(64).map { _.drop(32) }
+  val bitVectors24bits = bitVectors(24)
+  val bitVectors16bits = bitVectors(16)
+  val bitVectors14bits = bitVectors(14)
+  val bitVectors8bits = bitVectors(8)
+
+  @Benchmark def toInt_32bit_bigEndian_nonCompacted =
+    bitVectors32bitsNonCompacted.foldLeft(List[Int]()) { (acc, b) => b.toInt() :: acc }
+
+  @Benchmark def toInt_32bit_littleEndian_nonCompacted =
+    bitVectors32bitsNonCompacted.foldLeft(List[Int]()) { (acc, b) => b.toInt(ordering = ByteOrdering.LittleEndian) :: acc }
+
+  @Benchmark def toInt_32bit_bigEndian =
+    bitVectors32bits.foldLeft(List[Int]()) { (acc, b) => b.toInt() :: acc }
+
+  @Benchmark def toInt_32bit_littleEndian =
+    bitVectors32bits.foldLeft(List[Int]()) { (acc, b) => b.toInt(ordering = ByteOrdering.LittleEndian) :: acc }
+
+  @Benchmark def toInt_16bit_bigEndian =
+    bitVectors16bits.foldLeft(List[Int]()) { (acc, b) => b.toInt() :: acc }
+
+  @Benchmark def toInt_16bit_littleEndian =
+    bitVectors16bits.foldLeft(List[Int]()) { (acc, b) => b.toInt(ordering = ByteOrdering.LittleEndian) :: acc }
+
+  @Benchmark def toInt_16bit_bigEndian_unsigned =
+    bitVectors16bits.foldLeft(List[Int]()) { (acc, b) => b.toInt(signed = false) :: acc }
+
+  @Benchmark def toInt_16bit_littleEndian_unsigned =
+    bitVectors16bits.foldLeft(List[Int]()) { (acc, b) => b.toInt(signed = false, ordering = ByteOrdering.LittleEndian) :: acc }
+
+  @Benchmark def toInt_24bit_bigEndian =
+    bitVectors24bits.foldLeft(List[Int]()) { (acc, b) => b.toInt() :: acc }
+
+  @Benchmark def toInt_14bit_bigEndian =
+    bitVectors14bits.foldLeft(List[Int]()) { (acc, b) => b.toInt() :: acc }
+
+  @Benchmark def toInt_8bit_bigEndian =
+    bitVectors8bits.foldLeft(List[Int]()) { (acc, b) => b.toInt() :: acc }
+
+  @Benchmark def toLong_64bit_bigEndian =
+    bitVectors64bits.foldLeft(List[Long]()) { (acc, b) => b.toLong() :: acc }
+
+  @Benchmark def toLong_64bit_littleEndian =
+    bitVectors64bits.foldLeft(List[Long]()) { (acc, b) => b.toLong(ordering = ByteOrdering.LittleEndian) :: acc }
+
+  @Benchmark def toLong_60bit_bigEndian =
+    bitVectors60bits.foldLeft(List[Long]()) { (acc, b) => b.toLong() :: acc }
+
+  @Benchmark def toLong_32bit_bigEndian =
+    bitVectors32bits.foldLeft(List[Long]()) { (acc, b) => b.toLong() :: acc }
+
+  val ints = (0 to N).toList
+
+  @Benchmark def fromInt_32bit_bigEndian =
+    ints.foldLeft(List[BitVector]()) { (acc, n) => BitVector.fromInt(n) :: acc }
+
+  @Benchmark def fromInt_32bit_littleEndian =
+    ints.foldLeft(List[BitVector]()) { (acc, n) => BitVector.fromInt(n, ordering = ByteOrdering.LittleEndian) :: acc }
+
+  @Benchmark def fromInt_30bit_bigEndian =
+    ints.foldLeft(List[BitVector]()) { (acc, n) => BitVector.fromInt(n, size = 30) :: acc }
+
+  @Benchmark def fromInt_30bit_littleEndian =
+    ints.foldLeft(List[BitVector]()) { (acc, n) => BitVector.fromInt(n, size = 30, ordering = ByteOrdering.LittleEndian) :: acc }
+
+  @Benchmark def fromInt_16bit_bigEndian =
+    ints.foldLeft(List[BitVector]()) { (acc, n) => BitVector.fromInt(n, size = 16) :: acc }
+}


### PR DESCRIPTION
## toInt

`run -i 10 -wi 10 -f1 -t1 .*NumericConv.*`

### Before

```
[info] Benchmark                                                          Mode  Cnt    Score    Error  Units
[info] NumericConversionBenchmarks.fromInt_16bit_bigEndian                avgt   10  146.476 ±  7.589  us/op
[info] NumericConversionBenchmarks.fromInt_30bit_bigEndian                avgt   10  135.761 ± 10.377  us/op
[info] NumericConversionBenchmarks.fromInt_30bit_littleEndian             avgt   10  285.830 ± 20.083  us/op
[info] NumericConversionBenchmarks.fromInt_32bit_bigEndian                avgt   10   43.472 ±  3.357  us/op
[info] NumericConversionBenchmarks.fromInt_32bit_littleEndian             avgt   10   48.617 ±  2.885  us/op
[info] NumericConversionBenchmarks.toInt_14bit_bigEndian                  avgt   10   44.556 ±  3.599  us/op
[info] NumericConversionBenchmarks.toInt_16bit_bigEndian                  avgt   10   43.517 ±  0.852  us/op
[info] NumericConversionBenchmarks.toInt_16bit_bigEndian_unsigned         avgt   10   42.875 ±  1.438  us/op
[info] NumericConversionBenchmarks.toInt_16bit_littleEndian               avgt   10   82.882 ±  4.141  us/op
[info] NumericConversionBenchmarks.toInt_16bit_littleEndian_unsigned      avgt   10   80.745 ±  1.668  us/op
[info] NumericConversionBenchmarks.toInt_24bit_bigEndian                  avgt   10   55.102 ±  1.550  us/op
[info] NumericConversionBenchmarks.toInt_32bit_bigEndian                  avgt   10   66.239 ±  2.126  us/op
[info] NumericConversionBenchmarks.toInt_32bit_bigEndian_nonCompacted     avgt   10   65.913 ±  1.748  us/op
[info] NumericConversionBenchmarks.toInt_32bit_littleEndian               avgt   10  110.445 ±  3.446  us/op
[info] NumericConversionBenchmarks.toInt_32bit_littleEndian_nonCompacted  avgt   10  133.427 ±  5.729  us/op
[info] NumericConversionBenchmarks.toInt_8bit_bigEndian                   avgt   10   43.952 ±  1.666  us/op
[info] NumericConversionBenchmarks.toLong_32bit_bigEndian                 avgt   10   77.413 ±  1.844  us/op
[info] NumericConversionBenchmarks.toLong_60bit_bigEndian                 avgt   10  113.957 ±  4.130  us/op
[info] NumericConversionBenchmarks.toLong_64bit_bigEndian                 avgt   10  116.911 ± 11.796  us/op
[info] NumericConversionBenchmarks.toLong_64bit_littleEndian              avgt   10  199.810 ±  4.788  us/op
```

### After

```
[info] Benchmark                                                          Mode  Cnt    Score    Error  Units
[info] NumericConversionBenchmarks.fromInt_16bit_bigEndian                avgt   10  124.248 ± 11.345  us/op
[info] NumericConversionBenchmarks.fromInt_30bit_bigEndian                avgt   10  147.310 ± 10.509  us/op
[info] NumericConversionBenchmarks.fromInt_30bit_littleEndian             avgt   10  288.634 ±  5.093  us/op
[info] NumericConversionBenchmarks.fromInt_32bit_bigEndian                avgt   10   28.400 ±  0.798  us/op
[info] NumericConversionBenchmarks.fromInt_32bit_littleEndian             avgt   10   48.125 ±  1.913  us/op
[info] NumericConversionBenchmarks.toInt_14bit_bigEndian                  avgt   10   58.432 ±  2.919  us/op
[info] NumericConversionBenchmarks.toInt_16bit_bigEndian                  avgt   10   48.174 ±  1.982  us/op
[info] NumericConversionBenchmarks.toInt_16bit_bigEndian_unsigned         avgt   10   46.671 ±  1.918  us/op
[info] NumericConversionBenchmarks.toInt_16bit_littleEndian               avgt   10   48.120 ±  2.634  us/op
[info] NumericConversionBenchmarks.toInt_16bit_littleEndian_unsigned      avgt   10   47.902 ±  3.283  us/op
[info] NumericConversionBenchmarks.toInt_24bit_bigEndian                  avgt   10   68.415 ±  2.728  us/op
[info] NumericConversionBenchmarks.toInt_32bit_bigEndian                  avgt   10   47.594 ±  1.152  us/op
[info] NumericConversionBenchmarks.toInt_32bit_bigEndian_nonCompacted     avgt   10   49.274 ±  2.916  us/op
[info] NumericConversionBenchmarks.toInt_32bit_littleEndian               avgt   10   48.272 ±  1.832  us/op
[info] NumericConversionBenchmarks.toInt_32bit_littleEndian_nonCompacted  avgt   10   48.003 ±  1.190  us/op
[info] NumericConversionBenchmarks.toInt_8bit_bigEndian                   avgt   10   43.301 ±  1.309  us/op
[info] NumericConversionBenchmarks.toLong_32bit_bigEndian                 avgt   10   34.476 ±  4.187  us/op
[info] NumericConversionBenchmarks.toLong_60bit_bigEndian                 avgt   10   89.732 ±  5.049  us/op
[info] NumericConversionBenchmarks.toLong_64bit_bigEndian                 avgt   10   31.587 ±  1.851  us/op
[info] NumericConversionBenchmarks.toLong_64bit_littleEndian              avgt   10   31.675 ±  0.892  us/op
```
