### PR TITLE
Topic/more to base64 perf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 1.0.10
 ======
  - Improve performance of `toInt` and `fromInt`, `toLong` and `fromLong`, etc.
+ - Further performance improvements in `toBase64`.
 
 1.0.9
 =====

--- a/benchmark/src/main/scala/ScodecBitsBenchmark.scala
+++ b/benchmark/src/main/scala/ScodecBitsBenchmark.scala
@@ -25,6 +25,7 @@ class ScodecBitsBenchmark {
   val byteStringChunks_M = (0L until M).map(b => ByteString(b.toByte)).toList
   val bytes_M = Array.tabulate(M.toInt)(i => i.toByte)
   val bitVector_M = bitChunks_M.foldLeft(BitVector.empty)(_ ++ _)
+  val bitVector_M_compact = bitVector_M.copy
   val byteVector_M = byteChunks_M.foldLeft(ByteVector.empty)(_ ++ _)
   val byteString_M = byteStringChunks_M.foldLeft(ByteString())(_ ++ _)
 
@@ -123,6 +124,10 @@ class ScodecBitsBenchmark {
 
   @Benchmark def toBase64(): String =
     bitVector_M.toBase64
+  @Benchmark def toBase64_compact(): String =
+    bitVector_M_compact.toBase64
   @Benchmark def toBase64_JRE(): String =
     java.util.Base64.getEncoder.encodeToString(bitVector_M.toByteArray)
+  @Benchmark def toBase64_JRE_compact(): String =
+    java.util.Base64.getEncoder.encodeToString(bitVector_M_compact.toByteArray)
 }


### PR DESCRIPTION
`run -i 10 -wi 10 -f1 -t1 .*toBase64.*`

### Before

```
[info] Benchmark                                 Mode  Cnt   Score   Error  Units
[info] ScodecBitsBenchmark.toBase64              avgt   10  20.976 ± 0.790  us/op
[info] ScodecBitsBenchmark.toBase64_JRE          avgt   10   9.855 ± 0.311  us/op
[info] ScodecBitsBenchmark.toBase64_JRE_compact  avgt   10   2.923 ± 0.130  us/op
[info] ScodecBitsBenchmark.toBase64_compact      avgt   10  10.217 ± 0.341  us/op
```

### After

```
[info] Benchmark                                 Mode  Cnt   Score   Error  Units
[info] ScodecBitsBenchmark.toBase64              avgt   10  10.658 ± 0.330  us/op
[info] ScodecBitsBenchmark.toBase64_JRE          avgt   10   9.636 ± 0.338  us/op
[info] ScodecBitsBenchmark.toBase64_JRE_compact  avgt   10   2.935 ± 0.110  us/op
[info] ScodecBitsBenchmark.toBase64_compact      avgt   10   3.559 ± 0.103  us/op
```
