### PR TITLE
Add type-safe === to BitVector and ByteVector

### DIFF
--- a/core/shared/src/main/scala/scodec/bits/ByteVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/ByteVector.scala
@@ -350,14 +350,14 @@ sealed trait ByteVector extends BitwiseOperations[ByteVector,Int] with Serializa
    * @group collection
    */
   final def startsWith(b: ByteVector): Boolean =
-    take(b.size) == b
+    take(b.size) === b
 
   /**
    * Returns true if this byte vector ends with the specified vector.
    * @group collection
    */
   final def endsWith(b: ByteVector): Boolean =
-    takeRight(b.size) == b
+    takeRight(b.size) === b
 
   /**
    * Finds the first index of the specified byte pattern in this vector.
@@ -1025,12 +1025,21 @@ sealed trait ByteVector extends BitwiseOperations[ByteVector,Int] with Serializa
   }
 
   /**
+   * Returns true if the specified `ByteVector` has the same contents as this vector.
+   * @group collection
+   */
+  final def ===(other: ByteVector): Boolean =
+    this.size == other.size &&
+    (0 until this.size).forall(i => this(i) == other(i))
+
+
+  /**
    * Returns true if the specified value is a `ByteVector` with the same contents as this vector.
+   * @see [[ByteVector.===]]
    * @group collection
    */
   override def equals(other: Any) = other match {
-    case that: ByteVector => this.size == that.size &&
-                             (0 until this.size).forall(i => this(i) == that(i))
+    case that: ByteVector => this === that
     case other => false
   }
 

--- a/core/shared/src/test/scala/scodec/bits/BitVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/BitVectorTest.scala
@@ -19,6 +19,12 @@ class BitVectorTest extends BitsSuite {
     }
   }
 
+  test("=== consistent with ==") {
+    forAll { (b: BitVector, b2: BitVector) =>
+      (b == b2) shouldBe (b === b2)
+    }
+  }
+
   test("compact is a no-op for already compact bit vectors") {
     val b = BitVector(0x80,0x90)
     (b.compact.underlying eq b.compact.underlying) shouldBe true

--- a/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
@@ -20,6 +20,12 @@ class ByteVectorTest extends BitsSuite {
     }
   }
 
+  test("=== consistent with ==") {
+    forAll { (b: ByteVector, b2: ByteVector) =>
+      (b == b2) shouldBe (b === b2)
+    }
+  }
+
   test("compact is a no-op for already compact byte vectors") {
     val b = ByteVector(0x80)
     (b.compact eq b.compact) shouldBe true


### PR DESCRIPTION
The == method now delegates through to === when the types match.