### PR TITLE
Take nowrap param in inflate

### DIFF
--- a/core/jvm/src/test/scala/scodec/bits/ByteVectorJvmTest.scala
+++ b/core/jvm/src/test/scala/scodec/bits/ByteVectorJvmTest.scala
@@ -60,6 +60,12 @@ class ByteVectorJvmTest extends BitsSuite {
     }
   }
 
+  test("gzip - nowrap") {
+    forAll { (x: ByteVector) =>
+      x.deflate(nowrap = true).inflate(nowrap = true) shouldBe Right(x)
+    }
+  }
+
   test("serialization") {
     forAll { (x: ByteVector) => serializationShouldRoundtrip(x) }
   }

--- a/core/shared/src/main/scala/scodec/bits/ByteVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/ByteVector.scala
@@ -923,14 +923,15 @@ sealed abstract class ByteVector extends BitwiseOperations[ByteVector,Int] with 
    * Decompresses this vector using ZLIB.
    *
    * @param chunkSize buffer size, in bytes, to use when compressing
+   * @param nowrap if true, will assume no ZLIB header and checksum
    * @group conversions
    */
-  final def inflate(chunkSize: Int = 4096): Either[DataFormatException, ByteVector] = {
+  final def inflate(chunkSize: Int = 4096, nowrap: Boolean = false): Either[DataFormatException, ByteVector] = {
     if (isEmpty) Right(this)
     else {
       val arr = toArray
 
-      val inflater = new Inflater
+      val inflater = new Inflater(nowrap)
       try {
         inflater.setInput(arr)
         try {


### PR DESCRIPTION
Previously if you passed `nowrap = true` to deflate, then calling
inflate would fail because `nowrap` would default to false, but the
header and checksum would be present.

Note: the `ZlibCodec.decode` method in scodec-core should also respect the `nowrap` param. I'm happy to make that change, but I assume it will have to wait until the master branch of scodec is depending on a version of scodec-bits that has this change?