### PR TITLE
Support compilation under -Xexperimental

### DIFF
--- a/core/shared/src/main/scala/scodec/bits/ByteVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/ByteVector.scala
@@ -486,7 +486,7 @@ sealed trait ByteVector extends BitwiseOperations[ByteVector,Int] with Serializa
    * @group collection
    */
   final def reverse: ByteVector =
-    ByteVector.view(i => apply(size - i - 1), size)
+    ByteVector.view((i: Int) => apply(size - i - 1), size)
 
   final def shiftLeft(n: Int): ByteVector =
     BitVector(this).shiftLeft(n.toLong).toByteVector


### PR DESCRIPTION
Scalac supports treating SAM types (aka functional interfaces) as
functions types. To date, this has only been enabled under
-Xexperimental, but it is intended to be enabled by default in Scala
2.12.

This isn't a strictly source compatble change the compiler.
For example, it can make more overloaded alternatives feasible, which
hampers parameter type inferences in the arguments to an call.

That happens with the overloads on `ByteVector.view`. This commit
explicitly specifies the anonymous function parameter type to work
under both the old and new regimes.

Here's the [failed community build](https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-integrate-community-build/250/consoleFull) in which I tried to enable SAM support
by default:

```
[scodec-bits] [error] /home/jenkins/workspace/scala-2.12.x-integrate-community-build/target-0.9.4/project-builds/scodec-bits-97ff9cbfe8ce1b8b19fb48ab267f52c3f38562f7/core/shared/src/main/scala/scodec/bits/ByteVector.scala:489: missing parameter type
[scodec-bits] [error]     ByteVector.view(i => apply(size - i - 1), size)
[scodec-bits] [error]                     ^
```

This was built against:

```
⚡ git log bceb361e327a5 --decorate --oneline  -1
bceb361 (retronym/series/1.0.x, origin/series/1.0.x, series/1.0.x) Setting version to 1.0.12-SNAPSHOT
```

to which I have targetted this pull request.