### PR TITLE
Future-proof for Scala 2.12 re: SAM support

### DIFF
--- a/core/shared/src/main/scala/scodec/bits/BitVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/BitVector.scala
@@ -1306,7 +1306,7 @@ object BitVector {
   def view(buffer: ByteBuffer, sizeInBits: Long): BitVector = {
     require(bytesNeededForBits(sizeInBits) <= Int.MaxValue,
       "Cannot have BitVector chunk larger than Int.MaxValue bytes: " + sizeInBits)
-    toBytes(ByteVector.view(ind => buffer.get(ind), bytesNeededForBits(sizeInBits).toInt), sizeInBits)
+    toBytes(ByteVector.view((ind: Int) => buffer.get(ind), bytesNeededForBits(sizeInBits).toInt), sizeInBits)
   }
 
   /**


### PR DESCRIPTION
In 2.12, and 2.11 -Xexperimental, SAM types compete
with FunctionN types, which breaks type inference
during overloading resolution when both the SAM and
FunctionN alternatives apply.

See also #44 