### PR TITLE
Remove unnecessary workaround for sbt-jmh cross compile

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,13 +49,5 @@ lazy val coreJS = core.js
 lazy val benchmark: Project = project.in(file("benchmark")).dependsOn(coreJVM).enablePlugins(JmhPlugin).
   settings(commonSettings: _*).
   settings(
-    publishArtifact := false,
-    // Work-around for issue with sbt-jmh from https://github.com/ktoso/sbt-jmh/issues/76
-    libraryDependencies := {
-      libraryDependencies.value.map {
-        case x if x.name == "sbt-jmh-extras" =>
-          x.cross(CrossVersion.binaryMapped(_ => "2.10"))
-        case x => x
-      }
-    }
+    publishArtifact := false
   )


### PR DESCRIPTION
The original issue seems to be solved[1, 2].
Additionally, as ktoso says, it'd be nice for us to upgrade sbt-jmh to the newer version.[1]

[1] https://github.com/ktoso/sbt-jmh/issues/76#issuecomment-247279609
[2] https://github.com/retronym/scala-jmh-suite/commit/cd281784250d9fdcd4306150873803481fa039e9

P.S.
BTW, I opened a PR to upgrade sbt-jmh :)
https://github.com/scodec/scodec-build/pull/1