### PR TITLE
Issue #76: Added tests and updated the comments for ByteVector and BitVector

### DIFF
--- a/core/jvm/src/test/scala/scodec/bits/ByteVectorJvmTest.scala
+++ b/core/jvm/src/test/scala/scodec/bits/ByteVectorJvmTest.scala
@@ -26,22 +26,29 @@ class ByteVectorJvmTest extends BitsSuite {
     ByteVector.fromBase64Descriptive("AB") shouldBe Right(hex"00")
     ByteVector.fromBase64Descriptive("ABC") shouldBe Right(hex"0010")
     ByteVector.fromBase64Descriptive("ABCD") shouldBe Right(hex"001083")
+    ByteVector.fromBase64Descriptive("ABCDA") shouldBe Left("Final base 64 quantum had only 1 digit - must have at least 2 digits")
+    ByteVector.fromBase64Descriptive("ABCDAB") shouldBe Right(hex"00108300")
   }
 
   test("fromBase64 - padding") {
     ByteVector.fromBase64Descriptive("AB==") shouldBe Right(hex"00")
     val paddingError = Left("Malformed padding - final quantum may optionally be padded with one or two padding characters such that the quantum is completed")
-    ByteVector.fromBase64Descriptive("A==") shouldBe paddingError
-    ByteVector.fromBase64Descriptive("AB=") shouldBe paddingError
     ByteVector.fromBase64Descriptive("A=") shouldBe paddingError
+    ByteVector.fromBase64Descriptive("A==") shouldBe paddingError
+    ByteVector.fromBase64Descriptive("A===") shouldBe paddingError
+    ByteVector.fromBase64Descriptive("A====") shouldBe paddingError
+    ByteVector.fromBase64Descriptive("AB=") shouldBe paddingError
+    ByteVector.fromBase64Descriptive("AB===") shouldBe paddingError
+    ByteVector.fromBase64Descriptive("ABC==") shouldBe paddingError
     ByteVector.fromBase64Descriptive("=") shouldBe paddingError
     ByteVector.fromBase64Descriptive("==") shouldBe paddingError
-    ByteVector.fromBase64Descriptive("A===") shouldBe paddingError
-    ByteVector.fromBase64Descriptive("AB===") shouldBe paddingError
-    ByteVector.fromBase64Descriptive("A====") shouldBe paddingError
+    ByteVector.fromBase64Descriptive("===") shouldBe paddingError
     ByteVector.fromBase64Descriptive("====") shouldBe paddingError
-    ByteVector.fromBase64Descriptive("ABC==") shouldBe paddingError
     ByteVector.fromBase64Descriptive("=====") shouldBe paddingError
+  }
+
+  test("fromBase64 - empty input string") {
+    ByteVector.fromBase64Descriptive("") shouldBe Right(ByteVector.empty)
   }
 
   test("buffer concurrency") {

--- a/core/shared/src/main/scala/scodec/bits/BitVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/BitVector.scala
@@ -1490,8 +1490,8 @@ object BitVector {
 
   /**
    * Constructs a `BitVector` from a base 64 string or returns an error message if the string is not valid base 64.
-   *
-   * The string may contain whitespace characters.
+   * Details pertaining to base 64 decoding can be found in the comment for ByteVector.fromBase64Descriptive.
+   * The string may contain whitespace characters which are ignored.
    * @group base
    */
   def fromBase64Descriptive(str: String, alphabet: Bases.Base64Alphabet = Bases.Alphabets.Base64): Either[String, BitVector] =
@@ -1499,16 +1499,16 @@ object BitVector {
 
   /**
    * Constructs a `BitVector` from a base 64 string or returns `None` if the string is not valid base 64.
-   *
-   * The string may contain whitespace characters.
+   * Details pertaining to base 64 decoding can be found in the comment for ByteVector.fromBase64Descriptive.
+   * The string may contain whitespace characters which are ignored.
    * @group base
    */
   def fromBase64(str: String, alphabet: Bases.Base64Alphabet = Bases.Alphabets.Base64): Option[BitVector] = fromBase64Descriptive(str, alphabet).right.toOption
 
   /**
    * Constructs a `BitVector` from a base 64 string or throws an IllegalArgumentException if the string is not valid base 64.
-   *
-   * The string may contain whitespace characters.
+   * Details pertaining to base 64 decoding can be found in the comment for ByteVector.fromBase64Descriptive.
+   * The string may contain whitespace characters which are ignored.
    *
    * @throws IllegalArgumentException if the string is not valid base 64
    * @group base

--- a/core/shared/src/main/scala/scodec/bits/ByteVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/ByteVector.scala
@@ -1709,8 +1709,13 @@ object ByteVector {
 
   /**
    * Constructs a `ByteVector` from a base 64 string or returns an error message if the string is not valid base 64.
-   *
-   * The string may contain whitespace characters.
+   * If the final encoding quantum does not contain 4 characters, i.e. the total number of characters is not evenly divisible
+   * by 4, padding is inferred if the final quantum contains 2 or 3 characters. This is to say that padding is optional as
+   * long as the inferred padding would yield a valid base 64 string. The input is considered invalid if the final quantum
+   * only contains a single character. If padding characters are present, they must be used in accordance with the base 64
+   * specification and no padding characters will be inferred.
+   * An empty input string results in an empty ByteVector.
+   * The string may contain whitespace characters which are ignored.
    * @group base
    */
   def fromBase64Descriptive(str: String, alphabet: Bases.Base64Alphabet = Bases.Alphabets.Base64): Either[String, ByteVector] = {
@@ -1792,16 +1797,16 @@ object ByteVector {
 
   /**
    * Constructs a `ByteVector` from a base 64 string or returns `None` if the string is not valid base 64.
-   *
-   * The string may contain whitespace characters.
+   * Details pertaining to base 64 decoding can be found in the comment for fromBase64Descriptive.
+   * The string may contain whitespace characters which are ignored.
    * @group base
    */
   def fromBase64(str: String, alphabet: Bases.Base64Alphabet = Bases.Alphabets.Base64): Option[ByteVector] = fromBase64Descriptive(str, alphabet).right.toOption
 
   /**
    * Constructs a `ByteVector` from a base 64 string or throws an IllegalArgumentException if the string is not valid base 64.
-   *
-   * The string may contain whitespace characters.
+   * Details pertaining to base 64 decoding can be found in the comment for fromBase64Descriptive.
+   * The string may contain whitespace characters which are ignored.
    *
    * @throws IllegalArgumentException if the string is not valid base 64
    * @group base


### PR DESCRIPTION
Updated the comments for the ByteVector and BitVector versions of the functions fromBase64, fromValidBase64, and fromBase64Descriptive. Added a test for an empty input string. Added a few more padding and non-divisible by 4 tests.