### PR TITLE
allow building on JDK 9+

### DIFF
--- a/core/shared/src/main/scala/scodec/bits/BitVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/BitVector.scala
@@ -1313,7 +1313,7 @@ object BitVector {
    * not to modify the contents of the buffer passed to this function.
    * @group constructors
    */
-  def view(buffer: ByteBuffer): BitVector = toBytes(ByteVector.view(buffer), buffer.limit.toLong * 8)
+  def view(buffer: ByteBuffer): BitVector = toBytes(ByteVector.view(buffer), buffer.limit().toLong * 8)
 
   /**
    * Constructs a `BitVector` from the first `sizeInBits` of the `ByteBuffer`.
@@ -1632,7 +1632,7 @@ object BitVector {
         require (pos < in.size)
         val bytesToRead = (in.size - pos) min chunkSizeInBytes.toLong
         val buf = in.map(java.nio.channels.FileChannel.MapMode.READ_ONLY, pos, bytesToRead)
-        require(buf.limit == bytesToRead)
+        require(buf.limit() == bytesToRead)
         Some((BitVector.view(buf), (in -> (pos + bytesToRead))))
       }
     }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,1 @@
-sbt.version=1.1.5
-
+sbt.version=1.1.6


### PR DESCRIPTION
as discovered by the Scala 2.12 community build.  we're trying to
get as many projects as we can to build on newer JDK versions.