### PR TITLE
Make padLeft/Right errors more verbose.

### DIFF
--- a/core/shared/src/main/scala/scodec/bits/BitVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/BitVector.scala
@@ -418,7 +418,7 @@ sealed abstract class BitVector extends BitwiseOperations[BitVector, Long] with 
    * @group collection
    */
   final def padRight(n: Long): BitVector =
-    if (n < size) throw new IllegalArgumentException(s"BitVector.padRight($n)")
+    if (n < size) throw new IllegalArgumentException(s"Trying to right-pad a vector of $size bits to only $n bits.")
     else this ++ BitVector.fill(n - size)(false)
 
   /**
@@ -428,7 +428,7 @@ sealed abstract class BitVector extends BitwiseOperations[BitVector, Long] with 
    * @group collection
    */
   final def padLeft(n: Long): BitVector =
-    if (n < size) throw new IllegalArgumentException(s"BitVector.padLeft($n)")
+    if (n < size) throw new IllegalArgumentException(s"Trying to left-pad a vector of $size bits to only $n bits.")
     else BitVector.fill(n - size)(false) ++ this
 
   /**


### PR DESCRIPTION
Believe somebody had previously requested this on Gitter and I found myself also scratching my head at the error messages recently, so they are now a little more verbose. "Trying to left-pad a vector of 96 bits to 64 bits."