### PR TITLE
Fixed #55 by deprecating grouped and replacing with groupedI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,13 @@
 *.class
 *.log
 tags
-
-# sbt specific
 dist/*
 target/
 lib_managed/
 src_managed/
 project/boot/
 project/plugins/project/
-
-# IDEA specific
 /.idea
-
-# Scala-IDE specific
 .scala_dependencies
+.bloop
+.metals

--- a/core/shared/src/main/scala/scodec/bits/BitVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/BitVector.scala
@@ -363,9 +363,16 @@ sealed abstract class BitVector extends BitwiseOperations[BitVector, Long] with 
    * Converts this vector in to a sequence of `n`-bit vectors.
    * @group collection
    */
-  final def grouped(n: Long): Stream[BitVector] =
-    if (isEmpty) Stream.empty
-    else take(n) #:: drop(n).grouped(n)
+  @deprecated("1.1.8", "Use groupedI instead")
+  final def grouped(n: Long): Stream[BitVector] = groupedI(n).toStream
+
+  /**
+   * Converts this vector in to a sequence of `n`-bit vectors.
+   * @group collection
+   */
+  final def groupedI(n: Long): Iterator[BitVector] =
+    if (isEmpty) Iterator.empty
+    else Iterator(take(n)) ++ drop(n).groupedI(n)
 
   /**
    * Returns the first bit of this vector or throws if vector is emtpy.

--- a/core/shared/src/main/scala/scodec/bits/BitVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/BitVector.scala
@@ -359,20 +359,15 @@ sealed abstract class BitVector extends BitwiseOperations[BitVector, Long] with 
    */
   final def containsSlice(slice: BitVector): Boolean = indexOfSlice(slice) >= 0
 
-  /**
-   * Converts this vector in to a sequence of `n`-bit vectors.
-   * @group collection
-   */
+  // This was public before version 1.1.8 so it must stay here for bincompat
+  // The public grouped method is adding via an extension method defined in the companion
   @deprecated("1.1.8", "Use groupedI instead")
-  final def grouped(n: Long): Stream[BitVector] = groupedI(n).toStream
+  private[bits] final def grouped(n: Long): Stream[BitVector] =
+    groupedIterator(n).toStream
 
-  /**
-   * Converts this vector in to a sequence of `n`-bit vectors.
-   * @group collection
-   */
-  final def groupedI(n: Long): Iterator[BitVector] =
+  private final def groupedIterator(n: Long): Iterator[BitVector] =
     if (isEmpty) Iterator.empty
-    else Iterator(take(n)) ++ drop(n).groupedI(n)
+    else Iterator(take(n)) ++ drop(n).groupedIterator(n)
 
   /**
    * Returns the first bit of this vector or throws if vector is emtpy.
@@ -2058,4 +2053,13 @@ object BitVector {
   private class SerializationProxy(private val bytes: Array[Byte], private val size: Long) extends Serializable {
     def readResolve: AnyRef = BitVector.view(bytes, size)
   }
+
+  implicit class GroupedOp(private val self: BitVector) extends AnyVal {
+    /**
+     * Converts this vector in to a sequence of `n`-bit vectors.
+     * @group collection
+     */
+    final def grouped(n: Long): Iterator[BitVector] = self.groupedIterator(n)
+  }
+
 }

--- a/core/shared/src/main/scala/scodec/bits/ByteVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/ByteVector.scala
@@ -429,10 +429,18 @@ sealed abstract class ByteVector extends BitwiseOperations[ByteVector, Long] wit
    * Converts this vector in to a sequence of `chunkSize`-byte vectors.
    * @group collection
    */
+  @deprecated("1.1.8", "Use groupedI instead")
   final def grouped(chunkSize: Long): Stream[ByteVector] =
-    if (isEmpty) Stream.empty
-    else if (size <= chunkSize) Stream(this)
-    else take(chunkSize) #:: drop(chunkSize).grouped(chunkSize)
+    groupedI(chunkSize).toStream
+
+  /**
+   * Converts this vector in to a sequence of `chunkSize`-byte vectors.
+   * @group collection
+   */
+  final def groupedI(chunkSize: Long): Iterator[ByteVector] =
+    if (isEmpty) Iterator.empty
+    else if (size <= chunkSize) Iterator(this)
+    else Iterator(take(chunkSize)) ++ drop(chunkSize).groupedI(chunkSize)
 
   /**
    * Returns the first byte of this vector or throws if vector is emtpy.

--- a/core/shared/src/main/scala/scodec/bits/ByteVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/ByteVector.scala
@@ -425,22 +425,15 @@ sealed abstract class ByteVector extends BitwiseOperations[ByteVector, Long] wit
    */
   final def containsSlice(slice: ByteVector): Boolean = indexOfSlice(slice) >= 0
 
-  /**
-   * Converts this vector in to a sequence of `chunkSize`-byte vectors.
-   * @group collection
-   */
-  @deprecated("1.1.8", "Use groupedI instead")
-  final def grouped(chunkSize: Long): Stream[ByteVector] =
-    groupedI(chunkSize).toStream
+  // This was public before version 1.1.8 so it must stay here for bincompat
+  // The public grouped method is adding via an extension method defined in the companion
+  private[bits] final def grouped(chunkSize: Long): Stream[ByteVector] =
+    groupedIterator(chunkSize).toStream
 
-  /**
-   * Converts this vector in to a sequence of `chunkSize`-byte vectors.
-   * @group collection
-   */
-  final def groupedI(chunkSize: Long): Iterator[ByteVector] =
+  private final def groupedIterator(chunkSize: Long): Iterator[ByteVector] =
     if (isEmpty) Iterator.empty
     else if (size <= chunkSize) Iterator(this)
-    else Iterator(take(chunkSize)) ++ drop(chunkSize).groupedI(chunkSize)
+    else Iterator(take(chunkSize)) ++ drop(chunkSize).groupedIterator(chunkSize)
 
   /**
    * Returns the first byte of this vector or throws if vector is emtpy.
@@ -2078,4 +2071,12 @@ object ByteVector {
    * @group constructors
    */
   def unapplySeq(b: ByteVector): Some[Seq[Byte]] = Some(b.toIndexedSeq)
+
+  implicit class GroupedOp(private val self: ByteVector) extends AnyVal {
+    /**
+     * Converts this vector in to a sequence of `chunkSize`-byte vectors.
+     * @group collection
+     */
+    final def grouped(chunkSize: Long): Iterator[ByteVector] = self.groupedIterator(chunkSize)
+  }
 }

--- a/core/shared/src/test/scala/scodec/bits/BitVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/BitVectorTest.scala
@@ -390,14 +390,14 @@ class BitVectorTest extends BitsSuite {
     """bin"asdf"""" shouldNot compile
   }
 
-  test("grouped + concatenate") {
+  test("groupedI + concatenate") {
     forAll { (bv: BitVector) =>
       if (bv.isEmpty) {
-        bv.grouped(1) shouldBe Stream.empty
+        bv.groupedI(1).toList shouldBe Nil
       } else if (bv.size < 3) {
-        bv.grouped(bv.size) shouldBe Stream(bv)
+        bv.groupedI(bv.size).toList shouldBe List(bv)
       } else {
-        bv.grouped(bv.size / 3).toList.foldLeft(BitVector.empty) { (acc, b) => acc ++ b } shouldBe bv
+        bv.groupedI(bv.size / 3).toList.foldLeft(BitVector.empty) { (acc, b) => acc ++ b } shouldBe bv
       }
     }
   }

--- a/core/shared/src/test/scala/scodec/bits/BitVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/BitVectorTest.scala
@@ -390,14 +390,14 @@ class BitVectorTest extends BitsSuite {
     """bin"asdf"""" shouldNot compile
   }
 
-  test("groupedI + concatenate") {
+  test("grouped + concatenate") {
     forAll { (bv: BitVector) =>
       if (bv.isEmpty) {
-        bv.groupedI(1).toList shouldBe Nil
+        bv.grouped(1).toList shouldBe Nil
       } else if (bv.size < 3) {
-        bv.groupedI(bv.size).toList shouldBe List(bv)
+        bv.grouped(bv.size).toList shouldBe List(bv)
       } else {
-        bv.groupedI(bv.size / 3).toList.foldLeft(BitVector.empty) { (acc, b) => acc ++ b } shouldBe bv
+        bv.grouped(bv.size / 3).toList.foldLeft(BitVector.empty) { (acc, b) => acc ++ b } shouldBe bv
       }
     }
   }

--- a/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
@@ -311,14 +311,14 @@ class ByteVectorTest extends BitsSuite {
     }
   }
 
-  test("groupedI + concatenate") {
+  test("grouped + concatenate") {
     forAll { (bv: ByteVector) =>
       if (bv.isEmpty) {
-        bv.groupedI(1).toList shouldBe Nil 
+        bv.grouped(1).toList shouldBe Nil 
       } else if (bv.size < 3) {
-        bv.groupedI(bv.size).toList shouldBe List(bv)
+        bv.grouped(bv.size).toList shouldBe List(bv)
       } else {
-        bv.groupedI(bv.size / 3).toList.foldLeft(ByteVector.empty) { (acc, b) => acc ++ b } shouldBe bv
+        bv.grouped(bv.size / 3).toList.foldLeft(ByteVector.empty) { (acc, b) => acc ++ b } shouldBe bv
       }
     }
   }

--- a/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
@@ -311,14 +311,14 @@ class ByteVectorTest extends BitsSuite {
     }
   }
 
-  test("grouped + concatenate") {
+  test("groupedI + concatenate") {
     forAll { (bv: ByteVector) =>
       if (bv.isEmpty) {
-        bv.grouped(1) shouldBe Stream.empty
+        bv.groupedI(1).toList shouldBe Nil 
       } else if (bv.size < 3) {
-        bv.grouped(bv.size) shouldBe Stream(bv)
+        bv.groupedI(bv.size).toList shouldBe List(bv)
       } else {
-        bv.grouped(bv.size / 3).toList.foldLeft(ByteVector.empty) { (acc, b) => acc ++ b } shouldBe bv
+        bv.groupedI(bv.size / 3).toList.foldLeft(ByteVector.empty) { (acc, b) => acc ++ b } shouldBe bv
       }
     }
   }


### PR DESCRIPTION
Fix for #55 -- `grouped` should return an `Iterator` instead of a `Stream`.