### PR TITLE
BitVector.toLong for signed negative from 33 to 63 bits

### DIFF
--- a/core/shared/src/main/scala/scodec/bits/BitVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/BitVector.scala
@@ -952,7 +952,7 @@ sealed abstract class BitVector extends BitwiseOperations[BitVector, Long] with 
     go(0)
     if (mod != 0) result = result >>> (8 - mod)
     // Sign extend if necessary
-    if (signed && bits != 64 && ((1 << (bits - 1)) & result) != 0) {
+    if (signed && bits != 64 && ((1L << (bits - 1)) & result) != 0) {
       val toShift = 64 - bits
       result = (result << toShift) >> toShift
     }

--- a/core/shared/src/test/scala/scodec/bits/BitVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/BitVectorTest.scala
@@ -511,6 +511,11 @@ class BitVectorTest extends BitsSuite {
         BitVector.fromLong(n, size = 15, ordering = ByteOrdering.LittleEndian).toLong(ordering = ByteOrdering.LittleEndian) shouldBe n
       }
     }
+
+    forAll (Gen.choose(Long.MinValue >> 8, Long.MinValue >> 16)) { (n: Long) =>
+      BitVector.fromLong(n, size = 56, ordering = ByteOrdering.BigEndian).toLong(ordering = ByteOrdering.BigEndian) shouldBe n
+      BitVector.fromLong(n, size = 56, ordering = ByteOrdering.LittleEndian).toLong(ordering = ByteOrdering.LittleEndian) shouldBe n
+    }
   }
 
   test("UUID conversions") {


### PR DESCRIPTION
BitVector.toLong was failing to decode large negative longs not encoded in 64 bits because the test on the sign was between an Int and Long, the shift was not triggered. 

correction and test in commit