### PR TITLE
Base32 support

### DIFF
--- a/core/shared/src/main/scala/scodec/bits/Bases.scala
+++ b/core/shared/src/main/scala/scodec/bits/Bases.scala
@@ -39,6 +39,9 @@ object Bases {
   /** An alphabet that supports hexadecimal conversion. */
   trait HexAlphabet extends Alphabet
 
+  /** An alphabet that supports base 32 conversion. */
+  trait Base32Alphabet extends PaddedAlphabet
+
   /** An alphabet that supports base 64 conversion. */
   trait Base64Alphabet extends PaddedAlphabet
 
@@ -92,11 +95,62 @@ object Bases {
       def toChar(i: Int) = Chars(i)
     }
 
-    /** Base 58 alphabet as defined by [[https://en.bitcoin.it/wiki/Base58Check_encoding#Base58_symbol_chart]]. IPFS hashes uses the same order */
+    private def charIndicesLookupArray(indicesMap: Map[Char, Int]): (Int, Array[Int]) = {
+      val indicesMin: Int = indicesMap.keys.min
+      val indices: Array[Int] = Array.tabulate[Int](indicesMap.keys.max - indicesMin + 1) { i =>
+        indicesMap.getOrElse((i + indicesMin).toChar, -1)
+      }
+      (indicesMin, indices)
+    }
+
+    /** Base 32 alphabet as defined by [[https://tools.ietf.org/html/rfc4648#section-6 RF4648 section 4]]. Whitespace and hyphen is ignored. */
+    object Base32 extends Base32Alphabet {
+      private val Chars: Array[Char] = (('A' to 'Z') ++ ('2' to '7')).toArray
+      private val (indicesMin, indices) = charIndicesLookupArray {
+        val map = Map.from[Char, Int](Chars.zipWithIndex ++ Chars.map(_.toLower).zipWithIndex)
+        map ++ Map(
+          '0' -> map('O')
+        )
+      }
+      val pad = '='
+      def toChar(i: Int) = Chars(i)
+      def toIndex(c: Char) = {
+        val lookupIndex = c - indicesMin
+        if (lookupIndex >= 0 && lookupIndex < indices.length && indices(lookupIndex) >= 0) indices(lookupIndex)
+        else throw new IllegalArgumentException
+      }
+      def ignore(c: Char) = c == '-' || c.isWhitespace
+    }
+
+    /** Base 32 Crockford alphabet as defined by [[https://www.crockford.com/base32.html]]. Whitespace and hyphen is ignored. */
+    object Base32Crockford extends Base32Alphabet {
+      private val Chars: Array[Char] = (('0' to '9') ++ ('A' to 'H') ++ ('J' to 'K') ++ ('M' to 'N') ++ ('P' to 'Z')).toArray
+      private val (indicesMin, indices) = charIndicesLookupArray {
+        val map = Map.from[Char, Int](Chars.zipWithIndex ++ Chars.map(_.toLower).zipWithIndex)
+        map ++ Map(
+          'O' -> map('0'),
+          'o' -> map('0'),
+          'I' -> map('1'),
+          'i' -> map('1'),
+          'L' -> map('1'),
+          'l' -> map('1')
+        )
+      }
+      val pad = '='
+      def toChar(i: Int) = Chars(i)
+      def toIndex(c: Char) = {
+        val lookupIndex = c - indicesMin
+        if (lookupIndex >= 0 && lookupIndex < indices.length && indices(lookupIndex) >= 0) indices(lookupIndex)
+        else throw new IllegalArgumentException
+      }
+      def ignore(c: Char) = c == '-' || c.isWhitespace
+    }
+
+    /** Base 58 alphabet as defined by [[https://en.bitcoin.it/wiki/Base58Check_encoding#Base58_symbol_chart]]. IPFS hashes uses the same order. */
     object Base58 extends Alphabet {
       private val Chars = (('1' to '9') ++ ('A' to 'Z') ++ ('a' to 'z')).filterNot(c =>
-        List('O', 'I', 'l').exists(_ == c)
-      )
+        List('O', 'I', 'l').contains(c)
+      ).toArray
       def toChar(i: Int) = Chars(i)
       def toIndex(c: Char) = c match {
         case c if c >= '1' && c <= '9' => c - '1'
@@ -111,7 +165,7 @@ object Bases {
       def ignore(c: Char) = c.isWhitespace
     }
 
-    /** Base 64 alphabet as defined by [[http://tools.ietf.org/html/rfc4648#section-4 RF4648 section 4]]. Whitespace is ignored. */
+    /** Base 64 alphabet as defined by [[https://tools.ietf.org/html/rfc4648#section-4 RF4648 section 4]]. Whitespace is ignored. */
     object Base64 extends Base64Alphabet {
       private val Chars = (('A' to 'Z') ++ ('a' to 'z') ++ ('0' to '9') :+ '+' :+ '/').toArray
       val pad = '='
@@ -127,7 +181,7 @@ object Bases {
       def ignore(c: Char) = c.isWhitespace
     }
 
-    /** Base 64 alphabet as defined by [[http://tools.ietf.org/html/rfc4648#section-5 RF4648 section 5]]. Whitespace is ignored. */
+    /** Base 64 alphabet as defined by [[https://tools.ietf.org/html/rfc4648#section-5 RF4648 section 5]]. Whitespace is ignored. */
     object Base64Url extends Base64Alphabet {
       private val Chars = (('A' to 'Z') ++ ('a' to 'z') ++ ('0' to '9') :+ '-' :+ '_').toArray
       val pad = '='

--- a/core/shared/src/main/scala/scodec/bits/BitVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/BitVector.scala
@@ -775,7 +775,7 @@ sealed abstract class BitVector extends BitwiseOperations[BitVector, Long] with 
   final def toBase58(alphabet: Bases.Alphabet): String = toByteVector.toBase58(alphabet)
 
   /**
-    * Converts the contents of this vector to a base 64 string.
+    * Converts the contents of this vector to a base 32 string.
     *
     * The last byte is right-padded with zeros if the size is not evenly divisible by 8.
     *
@@ -784,7 +784,7 @@ sealed abstract class BitVector extends BitwiseOperations[BitVector, Long] with 
   final def toBase64: String = toBase64(Bases.Alphabets.Base64)
 
   /**
-    * Converts the contents of this vector to a base 64 string using the specified alphabet.
+    * Converts the contents of this vector to a base 32 string using the specified alphabet.
     *
     * The last byte is right-padded with zeros if the size is not evenly divisible by 8.
     *

--- a/core/shared/src/main/scala/scodec/bits/BitVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/BitVector.scala
@@ -739,6 +739,24 @@ sealed abstract class BitVector extends BitwiseOperations[BitVector, Long] with 
   }
 
   /**
+    * Converts the contents of this vector to a base 64 string.
+    *
+    * The last byte is right-padded with zeros if the size is not evenly divisible by 8.
+    *
+    * @group conversions
+    */
+  final def toBase32: String = toBase32(Bases.Alphabets.Base32)
+
+  /**
+    * Converts the contents of this vector to a base 64 string using the specified alphabet.
+    *
+    * The last byte is right-padded with zeros if the size is not evenly divisible by 8.
+    *
+    * @group conversions
+    */
+  final def toBase32(alphabet: Bases.Base32Alphabet): String = toByteVector.toBase32(alphabet)
+
+  /**
     * Converts the contents of this vector to a base 58 string.
     *
     * the order is assumed to be the same as (Bitcoin)[[https://en.bitcoin.it/wiki/Base58Check_encoding#Base58_symbol_chart]]

--- a/core/shared/src/main/scala/scodec/bits/BitVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/BitVector.scala
@@ -739,7 +739,7 @@ sealed abstract class BitVector extends BitwiseOperations[BitVector, Long] with 
   }
 
   /**
-    * Converts the contents of this vector to a base 64 string.
+    * Converts the contents of this vector to a base 32 string.
     *
     * The last byte is right-padded with zeros if the size is not evenly divisible by 8.
     *
@@ -748,7 +748,7 @@ sealed abstract class BitVector extends BitwiseOperations[BitVector, Long] with 
   final def toBase32: String = toBase32(Bases.Alphabets.Base32)
 
   /**
-    * Converts the contents of this vector to a base 64 string using the specified alphabet.
+    * Converts the contents of this vector to a base 32 string using the specified alphabet.
     *
     * The last byte is right-padded with zeros if the size is not evenly divisible by 8.
     *
@@ -775,7 +775,7 @@ sealed abstract class BitVector extends BitwiseOperations[BitVector, Long] with 
   final def toBase58(alphabet: Bases.Alphabet): String = toByteVector.toBase58(alphabet)
 
   /**
-    * Converts the contents of this vector to a base 32 string.
+    * Converts the contents of this vector to a base 64 string.
     *
     * The last byte is right-padded with zeros if the size is not evenly divisible by 8.
     *
@@ -784,7 +784,7 @@ sealed abstract class BitVector extends BitwiseOperations[BitVector, Long] with 
   final def toBase64: String = toBase64(Bases.Alphabets.Base64)
 
   /**
-    * Converts the contents of this vector to a base 32 string using the specified alphabet.
+    * Converts the contents of this vector to a base 64 string using the specified alphabet.
     *
     * The last byte is right-padded with zeros if the size is not evenly divisible by 8.
     *

--- a/core/shared/src/main/scala/scodec/bits/ByteVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/ByteVector.scala
@@ -1977,7 +1977,7 @@ object ByteVector extends ByteVectorPlatform {
 
   /**
     * Constructs a `ByteVector` from a base 64 string or returns `None` if the string is not valid base 32.
-    * Details pertaining to base 64 decoding can be found in the comment for fromBase32Descriptive.
+    * Details pertaining to base 32 decoding can be found in the comment for fromBase32Descriptive.
     * The string may contain whitespace characters which are ignored.
     * @group base
     */

--- a/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
@@ -180,6 +180,48 @@ class ByteVectorTest extends BitsSuite {
     assertThrows[IllegalArgumentException] { ByteVector.fromValidBin("1101a000") }
   }
 
+  test("toBase32") {
+    assert(hex"".toBase32 == (""))
+    assert(hex"00".toBase32 == ("AA======"))
+    assert(hex"61".toBase32 == ("ME======"))
+    assert(hex"626262".toBase32 == ("MJRGE==="))
+    assert(hex"636363".toBase32 == ("MNRWG==="))
+    assert(
+      hex"73696d706c792061206c6f6e6720737472696e67".toBase32 == ("ONUW24DMPEQGCIDMN5XGOIDTORZGS3TH")
+    )
+    assert(
+      hex"00eb15231dfceb60925886b67d065299925915aeb172c06647".toBase32 == ("ADVRKIY57TVWBESYQ23H2BSSTGJFSFNOWFZMAZSH")
+    )
+    assert(hex"516b6fcd0f".toBase32 == ("KFVW7TIP"))
+    assert(hex"bf4f89001e670274dd".toBase32 == ("X5HYSAA6M4BHJXI="))
+    assert(hex"572e4794".toBase32 == ("K4XEPFA="))
+    assert(hex"ecac89cad93923c02321".toBase32 == ("5SWITSWZHER4AIZB"))
+    assert(hex"10c8511e".toBase32 == ("CDEFCHQ="))
+    assert(hex"00000000000000000000".toBase32 == ("AAAAAAAAAAAAAAAA"))
+  }
+
+  test("fromValidBase32") {
+    assert(ByteVector.fromValidBase32("") == (ByteVector.empty))
+    assert(ByteVector.fromValidBase32("AA======") == hex"00")
+    assert(ByteVector.fromValidBase32("ME======") == (hex"61"))
+    assert(ByteVector.fromValidBase32("MJRGE===") == (hex"626262"))
+    assert(ByteVector.fromValidBase32("MNRWG===") == (hex"636363"))
+    assert(
+      ByteVector
+        .fromValidBase32("ONUW24DMPEQGCIDMN5XGOIDTORZGS3TH") == (hex"73696d706c792061206c6f6e6720737472696e67")
+    )
+    assert(
+      ByteVector
+        .fromValidBase32("ADVRKIY57TVWBESYQ23H2BSSTGJFSFNOWFZMAZSH") == (hex"00eb15231dfceb60925886b67d065299925915aeb172c06647")
+    )
+    assert(ByteVector.fromValidBase32("KFVW7TIP") == (hex"516b6fcd0f"))
+    assert(ByteVector.fromValidBase32("X5HYSAA6M4BHJXI=") == (hex"bf4f89001e670274dd"))
+    assert(ByteVector.fromValidBase32("K4XEPFA=") == (hex"572e4794"))
+    assert(ByteVector.fromValidBase32("5SWITSWZHER4AIZB") == (hex"ecac89cad93923c02321"))
+    assert(ByteVector.fromValidBase32("CDEFCHQ=") == (hex"10c8511e"))
+    assert(ByteVector.fromValidBase32("AAAAAAAAAAAAAAAA") == (hex"00000000000000000000"))
+  }
+
   test("toBase58") {
     assert(hex"".toBase58 == (""))
     assert(hex"00".toBase58 == ("1"))


### PR DESCRIPTION
This PR adds base32 support as in https://tools.ietf.org/html/rfc4648#section-6.
