### PR TITLE
Base32 RFC 4648 conformity

### DIFF
--- a/core/shared/src/main/scala/scodec/bits/Bases.scala
+++ b/core/shared/src/main/scala/scodec/bits/Bases.scala
@@ -106,10 +106,7 @@ object Bases {
     /** Base 32 alphabet as defined by [[https://tools.ietf.org/html/rfc4648#section-6 RF4648 section 4]]. Whitespace and hyphen is ignored. */
     object Base32 extends Base32Alphabet {
       private val Chars: Array[Char] = (('A' to 'Z') ++ ('2' to '7')).toArray
-      private val (indicesMin, indices) = charIndicesLookupArray {
-        val map = (Chars.zipWithIndex ++ Chars.map(_.toLower).zipWithIndex).toMap
-        map ++ Map('0' -> map('O'))
-      }
+      private val (indicesMin, indices) = charIndicesLookupArray(Chars.zipWithIndex.toMap)
       val pad = '='
       def toChar(i: Int) = Chars(i)
       def toIndex(c: Char) = {
@@ -118,7 +115,7 @@ object Bases {
           indices(lookupIndex)
         else throw new IllegalArgumentException
       }
-      def ignore(c: Char) = c == '-' || c.isWhitespace
+      def ignore(c: Char) = c.isWhitespace
     }
 
     /** Base 32 Crockford alphabet as defined by [[https://www.crockford.com/base32.html]]. Whitespace and hyphen is ignored. */

--- a/core/shared/src/main/scala/scodec/bits/Bases.scala
+++ b/core/shared/src/main/scala/scodec/bits/Bases.scala
@@ -103,7 +103,7 @@ object Bases {
       (indicesMin, indices)
     }
 
-    /** Base 32 alphabet as defined by [[https://tools.ietf.org/html/rfc4648#section-6 RF4648 section 4]]. Whitespace and hyphen is ignored. */
+    /** Base 32 alphabet as defined by [[https://tools.ietf.org/html/rfc4648#section-6 RF4648 section 4]]. Whitespace is ignored. */
     object Base32 extends Base32Alphabet {
       private val Chars: Array[Char] = (('A' to 'Z') ++ ('2' to '7')).toArray
       private val (indicesMin, indices) = charIndicesLookupArray(Chars.zipWithIndex.toMap)

--- a/core/shared/src/main/scala/scodec/bits/BitVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/BitVector.scala
@@ -1609,6 +1609,41 @@ object BitVector extends BitVectorPlatform {
     fromHexDescriptive(str, alphabet).fold(msg => throw new IllegalArgumentException(msg), identity)
 
   /**
+   * Constructs a `BitVector` from a base 32 string or returns an error message if the string is not valid base 32.
+   * Details pertaining to base 32 decoding can be found in the comment for ByteVector.fromBase32Descriptive.
+   * The string may contain whitespace characters which are ignored.
+   * @group base
+   */
+  def fromBase32Descriptive(
+      str: String,
+      alphabet: Bases.Base32Alphabet = Bases.Alphabets.Base32
+  ): Either[String, BitVector] =
+    ByteVector.fromBase32Descriptive(str, alphabet).map(_.toBitVector)
+
+  /**
+   * Constructs a `BitVector` from a base 32 string or returns `None` if the string is not valid base 32.
+   * Details pertaining to base 32 decoding can be found in the comment for ByteVector.fromBase32Descriptive.
+   * The string may contain whitespace characters which are ignored.
+   * @group base
+   */
+  def fromBase32(
+      str: String,
+      alphabet: Bases.Base32Alphabet = Bases.Alphabets.Base32
+  ): Option[BitVector] = fromBase32Descriptive(str, alphabet).toOption
+
+  /**
+   * Constructs a `BitVector` from a base 32 string or throws an IllegalArgumentException if the string is not valid base 32.
+   * Details pertaining to base 32 decoding can be found in the comment for ByteVector.fromBase32Descriptive.
+   * The string may contain whitespace characters which are ignored.
+   *
+   * @throws IllegalArgumentException if the string is not valid base 32
+   * @group base
+   */
+  def fromValidBase32(str: String, alphabet: Bases.Base32Alphabet = Bases.Alphabets.Base32): BitVector =
+    fromBase32Descriptive(str, alphabet)
+      .fold(msg => throw new IllegalArgumentException(msg), identity)
+
+  /**
     * Constructs a `BitVector` from a base 58 string or returns an error message if the string is not valid base 58.
     * Details pertaining to base 58 decoding can be found in the comment for ByteVector.fromBase58Descriptive.
     * The string may contain whitespace characters which are ignored.

--- a/core/shared/src/main/scala/scodec/bits/ByteVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/ByteVector.scala
@@ -1969,7 +1969,7 @@ object ByteVector extends ByteVectorPlatform {
       (((bytes.length + bitsPerChar - 1) / bitsPerChar * bitsPerChar) - bytes.length) * 8 / bitsPerChar
     if (padding != 0 && padding != expectedPadding)
       return Left(
-        "Malformed padding - final quantum may optionally be padded with one or two padding characters such that the quantum is completed"
+        s"Malformed padding - optionally expected $expectedPadding padding characters such that the quantum is completed"
       )
 
     Right(bytes)

--- a/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
@@ -229,6 +229,22 @@ class ByteVectorTest extends BitsSuite {
     assert(ByteVector.fromValidBase32("AAAAAAAAAAAAAAAA") == (hex"00000000000000000000"))
   }
 
+  test("fail due to illegal character fromBase32") {
+    assert(
+      ByteVector
+        .fromBase32Descriptive("7654321") == Left("Invalid base 32 character '1' at index 6")
+    )
+    assert(
+      ByteVector
+        .fromBase32Descriptive("ABc") == Left("Invalid base 32 character 'c' at index 2")
+    )
+    assert(
+      ByteVector
+        .fromBase32Descriptive("AB CD 0") == Left("Invalid base 32 character '0' at index 6")
+    )
+    assert(ByteVector.fromBase32("a").isEmpty)
+  }
+
   test("toBase58") {
     assert(hex"".toBase58 == (""))
     assert(hex"00".toBase58 == ("1"))


### PR DESCRIPTION
The base32 alphabet from my last PR is a bit too relaxed, allows lowercase characters and automatically parses a zero as an 'o'.
This is the right thing to do for the crockford alphabet but it is not permitted for the RFC one which is far more strict.
The crockford alphabet also allows '-' as an ignored character which the RFC doesn't allow.
I added tests to verify this behaviour.
Also I added the missing "fromBase32..." methods to BitVector.
