### PR TITLE
Add Scala 2.11.x support - 1.1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: scala
 
 scala:
-  - "2.12.10"
-  - "2.13.1"
+  - "2.11.12"
+  - "2.12.11"
+  - "2.13.2"
 
 jdk:
   - openjdk11
@@ -12,7 +13,7 @@ dist: trusty
 
 env:
   - SCALAJS_VERSION=0.6.32
-  - SCALAJS_VERSION=1.0.0-RC2
+  - SCALAJS_VERSION=1.0.0
 
 cache:
   directories:

--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,8 @@ lazy val commonSettings = Seq(
         List("-Xlint", "-Ywarn-unused")
       case v if v.startsWith("2.12") =>
         Nil
+      case v if v.startsWith("2.11") =>
+        Nil
       case other => sys.error(s"Unsupported scala version: $other")
     }),
   testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oD"),

--- a/core/shared/src/main/scala-2.11/scodec/bits/ScalaVersionSpecific.scala
+++ b/core/shared/src/main/scala-2.11/scodec/bits/ScalaVersionSpecific.scala
@@ -1,0 +1,9 @@
+package scodec.bits
+
+private[bits] trait ScalaVersionSpecific {
+  type IterableOnce[+A] = collection.GenTraversableOnce[A]
+
+  implicit class IterableOnceOps[A](private val self: IterableOnce[A]) {
+    def iterator: Iterator[A] = self.toIterator
+  }
+}


### PR DESCRIPTION
`crossScalaVersions := Seq("2.11.12", "2.12.11", "2.13.2"),`

```
$ sbt +test
[info] Run completed in 1 minute, 55 seconds.
[info] Total number of tests run: 129
[info] Suites: completed 3, aborted 0
[info] Tests: succeeded 129, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 129, Failed 0, Errors 0, Passed 129
[success] Total time: 208 s (03:28), completed Jun 17, 2020, 10:33:26 AM
```