### PR TITLE
Base64 NoPad/Url options -  1.1.x

### DIFF
--- a/core/jvm/src/test/scala/scodec/bits/ByteVectorJvmTest.scala
+++ b/core/jvm/src/test/scala/scodec/bits/ByteVectorJvmTest.scala
@@ -14,6 +14,27 @@ class ByteVectorJvmTest extends BitsSuite {
     }
   }
 
+  test("toBase64NoPad") {
+    forAll { (b: ByteVector) =>
+      val guavaB64 = com.google.common.io.BaseEncoding.base64.omitPadding()
+      ByteVector.view(guavaB64.decode(b.toBase64NoPad)) shouldBe b
+    }
+  }
+
+  test("toBase64Url") {
+    forAll { (b: ByteVector) =>
+      val guavaB64 = com.google.common.io.BaseEncoding.base64Url()
+      ByteVector.view(guavaB64.decode(b.toBase64Url)) shouldBe b
+    }
+  }
+
+  test("toBase64UrlNoPad") {
+    forAll { (b: ByteVector) =>
+      val guavaB64 = com.google.common.io.BaseEncoding.base64Url().omitPadding()
+      ByteVector.view(guavaB64.decode(b.toBase64UrlNoPad)) shouldBe b
+    }
+  }
+
   test("fromBase64") {
     forAll { (b: ByteVector) =>
       val guavaB64 = com.google.common.io.BaseEncoding.base64

--- a/core/shared/src/main/scala/scodec/bits/BitVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/BitVector.scala
@@ -794,6 +794,27 @@ sealed abstract class BitVector extends BitwiseOperations[BitVector, Long] with 
   final def toBase64(alphabet: Bases.Base64Alphabet): String = toByteVector.toBase64(alphabet)
 
   /**
+   * Converts the contents of this vector to a base 64 string without padding.
+   *
+   * @group conversions
+   */
+  final def toBase64NoPad: String = toByteVector.toBase64NoPad
+
+  /**
+   * Converts the contents of this vector to a base 64 string without padding.
+   *
+   * @group conversions
+   */
+  final def toBase64Url: String = toByteVector.toBase64Url
+
+  /**
+   * Converts the contents of this vector to a base 64 string without padding.
+   *
+   * @group conversions
+   */
+  final def toBase64UrlNoPad: String = toByteVector.toBase64UrlNoPad
+
+  /**
     * Convert a slice of bits from this vector (`start` until `start+bits`) to a `Byte`.
     *
     * @param signed whether sign extension should be performed

--- a/core/shared/src/main/scala/scodec/bits/ByteVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/ByteVector.scala
@@ -933,8 +933,12 @@ sealed abstract class ByteVector extends BitwiseOperations[ByteVector, Long] wit
       bldr
         .append(alphabet.toChar(first))
         .append(alphabet.toChar(second))
-        .append(alphabet.pad)
-        .append(alphabet.pad)
+
+      if (alphabet.pad != 0.toChar) {
+        bldr
+          .append(alphabet.pad)
+          .append(alphabet.pad)
+      }
     } else if (mod == 2) {
       var buffer = ((bytes(idx) & 0x0ff) << 10) | ((bytes(idx + 1) & 0x0ff) << 2)
       val third = buffer & 0x3f
@@ -942,14 +946,38 @@ sealed abstract class ByteVector extends BitwiseOperations[ByteVector, Long] wit
       val second = buffer & 0x3f
       buffer = buffer >> 6
       val first = buffer
+
       bldr
         .append(alphabet.toChar(first))
         .append(alphabet.toChar(second))
         .append(alphabet.toChar(third))
-        .append(alphabet.pad)
+
+      if (alphabet.pad != 0.toChar) bldr.append(alphabet.pad)
     }
     bldr.flip.toString
   }
+
+  /**
+   * Converts the contents of this vector to a base 64 string without padding.
+   *
+   * @group conversions
+   */
+  final def toBase64NoPad: String = toBase64(Bases.Alphabets.Base64NoPad)
+
+  /**
+   * Converts the contents of this vector to a base 64 url string with padding.
+   *
+   * @group conversions
+   */
+  final def toBase64Url: String = toBase64(Bases.Alphabets.Base64Url)
+
+  /**
+   * Converts the contents of this vector to a base 64 url string without padding.
+   *
+   * @group conversions
+   */
+  final def toBase64UrlNoPad: String = toBase64(Bases.Alphabets.Base64UrlNoPad)
+
 
   /**
     * Converts the contents of this vector to a byte.


### PR DESCRIPTION
Also adds support for `0.toChar` as indicating no padding which wasn't consistent in all of the base* helpers.