### PR TITLE
Implement `Ordered` interface in ByteVector and BitVector

### DIFF
--- a/core/shared/src/main/scala/scodec/bits/BitVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/BitVector.scala
@@ -32,7 +32,10 @@ import javax.crypto.Cipher
   *
   * @define bitwiseOperationsReprDescription bit vector
   */
-sealed abstract class BitVector extends BitwiseOperations[BitVector, Long] with Serializable {
+sealed abstract class BitVector
+    extends BitwiseOperations[BitVector, Long]
+    with Ordered[BitVector]
+    with Serializable {
   import BitVector._
 
   /**
@@ -739,17 +742,17 @@ sealed abstract class BitVector extends BitwiseOperations[BitVector, Long] with 
   }
 
   /**
-   * Helper alias of [[toHex():String*]]
-   *
-   * @group conversions
-   */
+    * Helper alias of [[toHex():String*]]
+    *
+    * @group conversions
+    */
   final def toBase16: String = toHex
 
   /**
-   * Helper alias of [[toHex(alpbabet:scodec\.bits\.Bases\.HexAlphabet):String*]]
-   *
-   * @group conversions
-   */
+    * Helper alias of [[toHex(alpbabet:scodec\.bits\.Bases\.HexAlphabet):String*]]
+    *
+    * @group conversions
+    */
   final def toBase16(alphabet: Bases.HexAlphabet): String = toHex(alphabet)
 
   /**
@@ -807,24 +810,24 @@ sealed abstract class BitVector extends BitwiseOperations[BitVector, Long] with 
   final def toBase64(alphabet: Bases.Base64Alphabet): String = toByteVector.toBase64(alphabet)
 
   /**
-   * Converts the contents of this vector to a base 64 string without padding.
-   *
-   * @group conversions
-   */
+    * Converts the contents of this vector to a base 64 string without padding.
+    *
+    * @group conversions
+    */
   final def toBase64NoPad: String = toByteVector.toBase64NoPad
 
   /**
-   * Converts the contents of this vector to a base 64 string without padding.
-   *
-   * @group conversions
-   */
+    * Converts the contents of this vector to a base 64 string without padding.
+    *
+    * @group conversions
+    */
   final def toBase64Url: String = toByteVector.toBase64Url
 
   /**
-   * Converts the contents of this vector to a base 64 string without padding.
-   *
-   * @group conversions
-   */
+    * Converts the contents of this vector to a base 64 string without padding.
+    *
+    * @group conversions
+    */
   final def toBase64UrlNoPad: String = toByteVector.toBase64UrlNoPad
 
   /**
@@ -1320,6 +1323,30 @@ sealed abstract class BitVector extends BitwiseOperations[BitVector, Long] with 
     )
 
   protected final def writeReplace(): AnyRef = new SerializationProxy(toByteArray, size)
+
+  override def compare(that: BitVector): Int =
+    if (this.eq(that)) {
+      0
+    } else {
+      val thisLength = this.length
+      val thatLength = that.length
+      val commonLength = thisLength.min(thatLength)
+      var i = 0
+      while (i < commonLength) {
+        val cmp = this(i).compare(that(i))
+        if (cmp != 0) {
+          return cmp
+        }
+        i = i + 1
+      }
+      if (thisLength < thatLength) {
+        -1
+      } else if (thisLength > thatLength) {
+        1
+      } else {
+        0
+      }
+    }
 }
 
 /**
@@ -1476,7 +1503,7 @@ object BitVector extends BitVectorPlatform {
 
   /**
     * Constructs a bit vector with the 2's complement encoding of the specified byte.
-    * @param s value to encode
+    * @param b value to encode
     * @param size size of vector (<= 8)
     * @group numeric
     */
@@ -1525,7 +1552,7 @@ object BitVector extends BitVectorPlatform {
 
   /**
     * Constructs a bit vector with the 2's complement encoding of the specified value.
-    * @param i value to encode
+    * @param l value to encode
     * @param size size of vector (<= 64)
     * @param ordering byte ordering of vector
     * @group numeric

--- a/core/shared/src/main/scala/scodec/bits/ByteVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/ByteVector.scala
@@ -1413,8 +1413,7 @@ sealed abstract class ByteVector
       val commonLength = thisLength.min(thatLength)
       var i = 0
       while (i < commonLength) {
-        import java.lang.Byte.toUnsignedInt
-        val cmp = toUnsignedInt(this(i)).compare(toUnsignedInt(that(i)))
+        val cmp = (this(i) & 0xFF).compare(that(i) & 0xFF)
         if (cmp != 0) {
           return cmp
         }

--- a/core/shared/src/main/scala/scodec/bits/ByteVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/ByteVector.scala
@@ -1413,7 +1413,8 @@ sealed abstract class ByteVector
       val commonLength = thisLength.min(thatLength)
       var i = 0
       while (i < commonLength) {
-        val cmp = this(i).compare(that(i))
+        import java.lang.Byte.toUnsignedInt
+        val cmp = toUnsignedInt(this(i)).compare(toUnsignedInt(that(i)))
         if (cmp != 0) {
           return cmp
         }

--- a/core/shared/src/main/scala/scodec/bits/ByteVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/ByteVector.scala
@@ -48,7 +48,10 @@ import scala.annotation.tailrec
   * @define bitwiseOperationsReprDescription bit vector
   * @define returnsView This method returns a view and hence, is O(1). Call [[compact]] to generate a new strict vector.
   */
-sealed abstract class ByteVector extends BitwiseOperations[ByteVector, Long] with Serializable {
+sealed abstract class ByteVector
+    extends BitwiseOperations[ByteVector, Long]
+    with Ordered[ByteVector]
+    with Serializable {
 
   import ByteVector._
 
@@ -801,17 +804,17 @@ sealed abstract class ByteVector extends BitwiseOperations[ByteVector, Long] wit
   }
 
   /**
-   * Helper alias for [[toHex:String*]]
-   *
-   * @group conversions
-   */
+    * Helper alias for [[toHex:String*]]
+    *
+    * @group conversions
+    */
   final def toBase16: String = toHex
 
   /**
-   * Helper alias for [[toHex(alphabet:scodec\.bits\.Bases\.HexAlphabet):String*]]
-   *
-   * @group conversions
-   */
+    * Helper alias for [[toHex(alphabet:scodec\.bits\.Bases\.HexAlphabet):String*]]
+    *
+    * @group conversions
+    */
   final def toBase16(alphabet: Bases.HexAlphabet): String = toHex(alphabet)
 
   /**
@@ -970,26 +973,25 @@ sealed abstract class ByteVector extends BitwiseOperations[ByteVector, Long] wit
   }
 
   /**
-   * Converts the contents of this vector to a base 64 string without padding.
-   *
-   * @group conversions
-   */
+    * Converts the contents of this vector to a base 64 string without padding.
+    *
+    * @group conversions
+    */
   final def toBase64NoPad: String = toBase64(Bases.Alphabets.Base64NoPad)
 
   /**
-   * Converts the contents of this vector to a base 64 url string with padding.
-   *
-   * @group conversions
-   */
+    * Converts the contents of this vector to a base 64 url string with padding.
+    *
+    * @group conversions
+    */
   final def toBase64Url: String = toBase64(Bases.Alphabets.Base64Url)
 
   /**
-   * Converts the contents of this vector to a base 64 url string without padding.
-   *
-   * @group conversions
-   */
+    * Converts the contents of this vector to a base 64 url string without padding.
+    *
+    * @group conversions
+    */
   final def toBase64UrlNoPad: String = toBase64(Bases.Alphabets.Base64UrlNoPad)
-
 
   /**
     * Converts the contents of this vector to a byte.
@@ -1401,6 +1403,30 @@ sealed abstract class ByteVector extends BitwiseOperations[ByteVector, Long] wit
       throw new IndexOutOfBoundsException(s"invalid index: $n for size $size")
 
   protected final def writeReplace(): AnyRef = new SerializationProxy(toArray)
+
+  override def compare(that: ByteVector): Int =
+    if (this.eq(that)) {
+      0
+    } else {
+      val thisLength = this.length
+      val thatLength = that.length
+      val commonLength = thisLength.min(thatLength)
+      var i = 0
+      while (i < commonLength) {
+        val cmp = this(i).compare(that(i))
+        if (cmp != 0) {
+          return cmp
+        }
+        i = i + 1
+      }
+      if (thisLength < thatLength) {
+        -1
+      } else if (thisLength > thatLength) {
+        1
+      } else {
+        0
+      }
+    }
 }
 
 /**

--- a/core/shared/src/test/scala/scodec/bits/BitVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/BitVectorTest.scala
@@ -697,4 +697,15 @@ class BitVectorTest extends BitsSuite {
   test("highByte") {
     assert(BitVector.highByte.toBin == "11111111")
   }
+
+  test("Ordered#compare") {
+    assert(BitVector[Int]().compare(BitVector[Int]()) == 0)
+    assert(BitVector(1).compare(BitVector(1)) == 0)
+    assert(BitVector[Int]() < BitVector(1))
+    assert(BitVector(1) < BitVector(1, 2))
+    assert(BitVector(1) > BitVector[Int]())
+    assert(BitVector(1, 2) > BitVector(1))
+    assert(BitVector(1, 2) < BitVector(2))
+    assert(BitVector(2) > BitVector(1, 2))
+  }
 }

--- a/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
@@ -647,5 +647,6 @@ class ByteVectorTest extends BitsSuite {
     assert(ByteVector(1, 2) > ByteVector(1))
     assert(ByteVector(1, 2) < ByteVector(2))
     assert(ByteVector(2) > ByteVector(1, 2))
+    assert(ByteVector(100) < ByteVector(200))
   }
 }

--- a/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
@@ -637,4 +637,15 @@ class ByteVectorTest extends BitsSuite {
       case ByteVector(0, 1, 2) => // OK
     }
   }
+
+  test("Ordered#compare") {
+    assert(ByteVector[Int]().compare(ByteVector[Int]()) == 0)
+    assert(ByteVector(1).compare(ByteVector(1)) == 0)
+    assert(ByteVector[Int]() < ByteVector(1))
+    assert(ByteVector(1) < ByteVector(1, 2))
+    assert(ByteVector(1) > ByteVector[Int]())
+    assert(ByteVector(1, 2) > ByteVector(1))
+    assert(ByteVector(1, 2) < ByteVector(2))
+    assert(ByteVector(2) > ByteVector(1, 2))
+  }
 }


### PR DESCRIPTION
Steps towards https://github.com/scodec/scodec-cats/issues/13

/cc @mpilquist 
