### PR TITLE
Fix Base32Crockford symbols

### DIFF
--- a/core/shared/src/main/scala/scodec/bits/Bases.scala
+++ b/core/shared/src/main/scala/scodec/bits/Bases.scala
@@ -124,7 +124,7 @@ object Bases {
     /** Base 32 Crockford alphabet as defined by [[https://www.crockford.com/base32.html]]. Whitespace and hyphen is ignored. */
     object Base32Crockford extends Base32Alphabet {
       private val Chars: Array[Char] =
-        (('0' to '9') ++ ('A' to 'H') ++ ('J' to 'K') ++ ('M' to 'N') ++ ('P' to 'Z')).toArray
+        (('0' to '9') ++ ('A' to 'H') ++ ('J' to 'K') ++ ('M' to 'N') ++ ('P' to 'T') ++ ('V' to 'Z')).toArray
       private val (indicesMin, indices) = charIndicesLookupArray {
         val map = (Chars.zipWithIndex ++ Chars.map(_.toLower).zipWithIndex).toMap
         map ++ Map(

--- a/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
@@ -248,6 +248,27 @@ class ByteVectorTest extends BitsSuite {
     assert(ByteVector.fromBase32("a").isEmpty)
   }
 
+  test("toBase32(Crockford)") {
+    import scodec.bits.Bases.Alphabets.{Base32Crockford => Crockford}
+
+    assert(hex"".toBase32(Crockford) == (""))
+    assert(hex"00".toBase32(Crockford) == ("00======"))
+    assert(hex"ffffffffff".toBase32(Crockford) == ("ZZZZZZZZ"))
+    assert(hex"8ca74adb5b".toBase32(Crockford) == ("HJKMNPTV"))
+  }
+
+  test("fromValidBase32(Crockford)") {
+    import scodec.bits.Bases.Alphabets.{Base32Crockford => Crockford}
+
+    assert(ByteVector.fromValidBase32("", Crockford) == (ByteVector.empty))
+    assert(ByteVector.fromValidBase32("00======", Crockford) == (hex"00"))
+    assert(ByteVector.fromValidBase32("ZZZZZZZZ", Crockford) == (hex"ffffffffff"))
+    assert(ByteVector.fromValidBase32("HJKMNPTV", Crockford) == (hex"8ca74adb5b"))
+    assert(ByteVector.fromValidBase32("hjkmnptv", Crockford) == (hex"8ca74adb5b"))
+    assert(ByteVector.fromValidBase32("00011111", Crockford) == (hex"0000108421"))
+    assert(ByteVector.fromValidBase32("0Oo1IiLl", Crockford) == (hex"0000108421"))
+  }
+
   test("toBase58") {
     assert(hex"".toBase58 == (""))
     assert(hex"00".toBase58 == ("1"))


### PR DESCRIPTION
Because `U` was mixed into the chars used by `Base32Crockford`, both encoding and decoding of strings containing symbols later `V` were broken.
This commit fix the problem, and add a simple test to check the correspondence of Strings with Bytes in typical cases.