### PR TITLE
Optimize BitVector's and ByteVector's equals

### DIFF
--- a/core/shared/src/main/scala/scodec/bits/BitVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/BitVector.scala
@@ -1221,20 +1221,23 @@ sealed abstract class BitVector
     * Returns true if the specified `BitVector` has the same contents as this vector.
     * @group collection
     */
-  final def ===(other: BitVector): Boolean = {
-    val chunkSize = 8L * 1024 * 64
-    @annotation.tailrec
-    def go(x: BitVector, y: BitVector): Boolean =
-      if (x.isEmpty) y.isEmpty
-      else {
-        val chunkX = x.take(chunkSize)
-        val chunkY = y.take(chunkSize)
-        chunkX.size == chunkY.size &&
-        chunkX.toByteVector === chunkY.toByteVector &&
-        go(x.drop(chunkSize), y.drop(chunkSize))
-      }
-    go(this, other)
-  }
+  final def ===(other: BitVector): Boolean =
+    if (this.eq(other)) true
+    else if (this.length != other.length) false
+    else {
+      val chunkSize = 8L * 1024 * 64
+      @annotation.tailrec
+      def go(x: BitVector, y: BitVector): Boolean =
+        if (x.isEmpty) y.isEmpty
+        else {
+          val chunkX = x.take(chunkSize)
+          val chunkY = y.take(chunkSize)
+          chunkX.toByteVector === chunkY.toByteVector &&
+          go(x.drop(chunkSize), y.drop(chunkSize))
+        }
+
+      go(this, other)
+    }
 
   /**
     * Returns true if the specified value is a `BitVector` with the same contents as this vector.

--- a/core/shared/src/main/scala/scodec/bits/ByteVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/ByteVector.scala
@@ -1351,21 +1351,23 @@ sealed abstract class ByteVector
     * Returns true if the specified `ByteVector` has the same contents as this vector.
     * @group collection
     */
-  final def ===(other: ByteVector): Boolean = {
-    val s = this.size
-    if (s != other.size)
-      false
+  final def ===(other: ByteVector): Boolean =
+    if (this.eq(other)) true
     else {
-      @annotation.tailrec
-      def go(i: Long): Boolean =
-        if (i < s)
-          if (this(i) == other(i)) go(i + 1)
-          else false
-        else
-          true
-      go(0)
+      val s = this.size
+      if (s != other.size)
+        false
+      else {
+        @annotation.tailrec
+        def go(i: Long): Boolean =
+          if (i < s)
+            if (this(i) == other(i)) go(i + 1)
+            else false
+          else
+            true
+        go(0)
+      }
     }
-  }
 
   /**
     * Returns true if the specified value is a `ByteVector` with the same contents as this vector.


### PR DESCRIPTION
@mpilquist wouldn't this be more efficient implementation of `equals`?