### PR TITLE
override foldRight on BitVector/ByteVector

### DIFF
--- a/core/shared/src/main/scala/scodec/bits/BitVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/BitVector.scala
@@ -690,6 +690,13 @@ sealed abstract class BitVector
         new IndexedSeq[Boolean] {
           def length = n
           def apply(idx: Int): Boolean = BitVector.this.get(idx.toLong)
+          override def foldRight[B](z: B)(op: (Boolean, B) => B): B = {
+            val it = reverseIterator
+            var b = z
+            while (it.hasNext)
+              b = op(it.next(), b)
+            b
+          }
         }
       }
       .getOrElse {

--- a/core/shared/src/main/scala/scodec/bits/ByteVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/ByteVector.scala
@@ -706,6 +706,7 @@ sealed abstract class ByteVector
     new IndexedSeq[Byte] {
       val length = toIntSize(ByteVector.this.size)
       def apply(i: Int) = ByteVector.this.apply(i.toLong)
+      override def foldRight[B](z: B)(op: (Byte, B) => B): B = ByteVector.this.foldRight(z)(op)
     }
 
   /**


### PR DESCRIPTION
workaround for https://github.com/scala/bug/issues/12137