### PR TITLE
avoid using type parameters on Left or Right

### DIFF
--- a/core/shared/src/main/scala-2/scodec/bits/package.scala
+++ b/core/shared/src/main/scala-2/scodec/bits/package.scala
@@ -66,13 +66,13 @@ package object bits extends ScalaVersionSpecific {
     def map[R2](f: R => R2): Either[L, R2] =
       self match {
         case Right(r)      => Right(f(r))
-        case l: Left[L, R] => l.asInstanceOf[Either[L, R2]]
+        case l             => l.asInstanceOf[Either[L, R2]]
       }
 
     def flatMap[R2](f: R => Either[L, R2]): Either[L, R2] =
       self match {
         case Right(r)      => f(r)
-        case l: Left[L, R] => l.asInstanceOf[Either[L, R2]]
+        case l             => l.asInstanceOf[Either[L, R2]]
       }
 
     def toOption: Option[R] =


### PR DESCRIPTION
this future-proofs the code for scala/scala#9303,
and IMO the new code is just as good anyway