### PR TITLE
ByteVector.toInputStream method

### DIFF
--- a/core/shared/src/main/scala/scodec/bits/ByteVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/ByteVector.scala
@@ -42,6 +42,7 @@ import java.security.{
 }
 import java.util.UUID
 import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
+import java.util.function.IntUnaryOperator
 import java.util.zip.{DataFormatException, Deflater, Inflater}
 
 import javax.crypto.Cipher
@@ -2342,11 +2343,13 @@ object ByteVector extends ByteVectorPlatform {
     override def read(b: Array[Byte], off: Int, len: Int): Int = {
       var l: Int = -1
 
-      val cpos: Int = pos.getAndUpdate { (cpos: Int) =>
-        l = Math.min(len, bvlen - cpos)
+      val cpos: Int = pos.getAndUpdate(new IntUnaryOperator {
+        override def applyAsInt(cpos: Int): Int = {
+          l = Math.min(len, bvlen - cpos)
 
-        cpos + l
-      }
+          cpos + l
+        }
+      })
 
       if (cpos >= bvlen) return -1
 

--- a/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
@@ -710,9 +710,9 @@ class ByteVectorTest extends BitsSuite {
     {
       val is = ByteVector((0 to 9).toArray.map(_.toByte)).toInputStream
       assert(is.available() == 10)
-      is.readNBytes(5)
+      is.read(Array.fill(5)(0.toByte))
       assert(is.available() == 5)
-      is.readNBytes(0)
+      is.read(Array.empty)
       assert(is.available() == 5)
       assert(Source.fromInputStream(is).map(_.toInt.toString).mkString == "56789")
       assert(is.available() == 0)
@@ -720,9 +720,9 @@ class ByteVectorTest extends BitsSuite {
     {
       val is = ByteVector((0 to 14).toArray.map(_.toByte)).toInputStream
       assert(is.available() == 15)
-      is.readNBytes(5)
+      is.read(Array.fill(5)(0.toByte))
       assert(is.available() == 10)
-      is.readNBytes(5)
+      is.read(Array.fill(5)(0.toByte))
       assert(is.available() == 5)
       assert(Source.fromInputStream(is).map(_.toInt.toString).mkString == "1011121314")
       assert(is.available() == 0)
@@ -730,22 +730,29 @@ class ByteVectorTest extends BitsSuite {
     {
       val is = ByteVector((0 to 14).toArray.map(_.toByte)).toInputStream
 
-      assert(is.readAllBytes().map(_.toInt.toString).mkString == "01234567891011121314")
+      val a = Array.fill(500)(0.toByte)
+      assert(is.read(a) == 15)
+      assert(a.take(15).map(_.toInt.toString).mkString == "01234567891011121314")
+      a.drop(15).foreach(b => assert(b == 0))
       assert(is.available() == 0)
     }
     {
       val is = ByteVector.empty.toInputStream
 
       assert(is.available() == 0)
-      assert(is.readAllBytes().isEmpty)
+      val a = Array.empty[Byte]
+      assert(is.read(a) == -1)
       assert(is.available() == 0)
     }
     {
       val is = ByteVector((0 to 9).toArray.map(_.toByte)).toInputStream
       assert(is.available() == 10)
-      assert(is.readNBytes(15).map(_.toInt).mkString == "0123456789")
+      val a = Array.fill(500)(0.toByte)
+      assert(is.read(a) == 10)
+      assert(a.take(10).map(_.toInt.toString).mkString == "0123456789")
+      a.drop(10).foreach(b => assert(b == 0))
       assert(is.available() == 0)
-      is.readNBytes(0)
+      assert(is.read(a) == -1)
       assert(is.available() == 0)
     }
   }

--- a/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
@@ -33,7 +33,6 @@ package scodec.bits
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import java.util.{Arrays, UUID}
-import scala.io.Source
 import Arbitraries._
 import org.scalacheck._
 import Prop.forAll
@@ -705,7 +704,9 @@ class ByteVectorTest extends BitsSuite {
     {
       val is = ByteVector(0, 1, 2).toInputStream
       assert(is.available() == 3)
-      assert(Source.fromInputStream(is).map(_.toInt.toString).mkString == "012")
+      val a = Array.fill(50)(0.toByte)
+      assert(is.read(a) == 3)
+      assert(a.take(3).map(_.toInt.toString).mkString == "012")
     }
     {
       val is = ByteVector((0 to 9).toArray.map(_.toByte)).toInputStream
@@ -714,7 +715,9 @@ class ByteVectorTest extends BitsSuite {
       assert(is.available() == 5)
       is.read(Array.empty)
       assert(is.available() == 5)
-      assert(Source.fromInputStream(is).map(_.toInt.toString).mkString == "56789")
+      val a = Array.fill(50)(0.toByte)
+      assert(is.read(a) == 5)
+      assert(a.take(5).map(_.toInt.toString).mkString == "56789")
       assert(is.available() == 0)
     }
     {
@@ -724,7 +727,9 @@ class ByteVectorTest extends BitsSuite {
       assert(is.available() == 10)
       is.read(Array.fill(5)(0.toByte))
       assert(is.available() == 5)
-      assert(Source.fromInputStream(is).map(_.toInt.toString).mkString == "1011121314")
+      val a = Array.fill(50)(0.toByte)
+      assert(is.read(a) == 5)
+      assert(a.take(5).map(_.toInt.toString).mkString == "1011121314")
       assert(is.available() == 0)
     }
     {


### PR DESCRIPTION
Hello,
I needed to convert the `ByteVector` to `InputStream` and surprisingly, that is not supported yet. Here is the implementation so everyone could use that.