### PR TITLE
Use `Uint8Array` instead of `Int8Array` for JS interop

### DIFF
--- a/core/js/src/main/scala/scodec/bits/ByteVectorCompanionCrossPlatform.scala
+++ b/core/js/src/main/scala/scodec/bits/ByteVectorCompanionCrossPlatform.scala
@@ -30,18 +30,18 @@
 
 package scodec.bits
 
-import scala.scalajs.js.typedarray.{ArrayBuffer, Int8Array, TypedArrayBuffer}
+import scala.scalajs.js.typedarray.{ArrayBuffer, Uint8Array, TypedArrayBuffer}
 
 private[bits] trait ByteVectorCompanionCrossPlatform extends ByteVectorPlatform { self: ByteVector.type =>
-  def view(typedArray: Int8Array): ByteVector = ByteVector.view(TypedArrayBuffer.wrap(typedArray))
+  def view(typedArray: Uint8Array): ByteVector = ByteVector.view(typedArray.buffer)
 
   def view(arrayBuffer: ArrayBuffer): ByteVector = ByteVector.view(TypedArrayBuffer.wrap(arrayBuffer))
 
-  def fromTypedArray(typedArray: Int8Array): ByteVector = {
-    val copy = new Int8Array(typedArray.length)
+  def fromUint8Array(typedArray: Uint8Array): ByteVector = {
+    val copy = new Uint8Array(typedArray.length)
     copy.set(typedArray)
     ByteVector.view(copy)
   }
 
-  def fromArrayBuffer(arrayBuffer: ArrayBuffer): ByteVector = ByteVector.fromTypedArray(new Int8Array(arrayBuffer))
+  def fromJSArrayBuffer(arrayBuffer: ArrayBuffer): ByteVector = ByteVector.fromUint8Array(new Uint8Array(arrayBuffer))
 }

--- a/core/js/src/main/scala/scodec/bits/ByteVectorCrossPlatform.scala
+++ b/core/js/src/main/scala/scodec/bits/ByteVectorCrossPlatform.scala
@@ -30,15 +30,15 @@
 
 package scodec.bits
 
-import scala.scalajs.js.typedarray.Int8Array
+import scala.scalajs.js.typedarray.Uint8Array
 
 private[bits] trait ByteVectorCrossPlatform { self: ByteVector =>
-  def copyToTypedArray(dest: Int8Array, start: Int): Unit = {
+  def copyToUint8Array(dest: Uint8Array, start: Int): Unit = {
     val len: Int = self.intSize.getOrElse(throw new RuntimeException("ByteVector too large!"))
-    self.copyToTypedArray(dest, start, 0, len)
+    self.copyToUint8Array(dest, start, 0, len)
   }
 
-  def copyToTypedArray(dest: Int8Array, start: Int, offset: Long, size: Int): Unit = {
+  def copyToUint8Array(dest: Uint8Array, start: Int, offset: Long, size: Int): Unit = {
     var i = 0
     while (i < size) {
       dest(start + i) = self(offset + i)
@@ -46,10 +46,10 @@ private[bits] trait ByteVectorCrossPlatform { self: ByteVector =>
     }
   }
 
-  def toTypedArray: Int8Array = {
+  def toUint8Array: Uint8Array = {
     val len = self.intSize.getOrElse(throw new RuntimeException("ByteVector too large!"))
-    val dest = new Int8Array(len)
-    self.copyToTypedArray(dest, 0, 0, len)
+    val dest = new Uint8Array(len)
+    self.copyToUint8Array(dest, 0, 0, len)
     dest
   }
 }

--- a/core/js/src/test/scala/scodec/bits/ByteVectorJsTest.scala
+++ b/core/js/src/test/scala/scodec/bits/ByteVectorJsTest.scala
@@ -30,63 +30,63 @@
 
 package scodec.bits
 
-import scala.scalajs.js.typedarray.{ArrayBuffer, Int8Array}
+import scala.scalajs.js.typedarray.{ArrayBuffer, Uint8Array}
 
 class ByteVectorJsTest extends BitsSuite {
-  private def setDEADBEEF(int8Array: Int8Array): Unit = {
-    int8Array(0) = 0xDE.toByte
-    int8Array(1) = 0xAD.toByte
-    int8Array(2) = 0xBE.toByte
-    int8Array(3) = 0xEF.toByte
+  private def setDEADBEEF(uint8Array: Uint8Array): Unit = {
+    uint8Array(0) = 0xde.toByte
+    uint8Array(1) = 0xad.toByte
+    uint8Array(2) = 0xbe.toByte
+    uint8Array(3) = 0xef.toByte
   }
 
-  test("view(Int8Array)") {
-    val int8Array = new Int8Array(4)
-    setDEADBEEF(int8Array)
-    val byteVector: ByteVector = ByteVector.view(int8Array)
+  test("view(Uint8Array)") {
+    val uint8Array = new Uint8Array(4)
+    setDEADBEEF(uint8Array)
+    val byteVector: ByteVector = ByteVector.view(uint8Array)
     assert(byteVector === hex"deadbeef")
-    int8Array(3) = 0xEE.toByte
+    uint8Array(3) = 0xee.toByte
     assert(byteVector === hex"deadbeee")
   }
 
   test("view(ArrayBuffer)") {
     val arrayBuffer = new ArrayBuffer(4)
-    val int8Array = new Int8Array(arrayBuffer)
-    setDEADBEEF(int8Array)
+    val uint8Array = new Uint8Array(arrayBuffer)
+    setDEADBEEF(uint8Array)
     val byteVector: ByteVector = ByteVector.view(arrayBuffer)
     assert(byteVector === hex"deadbeef")
-    int8Array(3) = 0xEE.toByte
+    uint8Array(3) = 0xee.toByte
     assert(byteVector === hex"deadbeee")
   }
 
   test("fromTypedArray") {
-    val int8Array = new Int8Array(4)
-    setDEADBEEF(int8Array)
-    val byteVector: ByteVector = ByteVector.fromTypedArray(int8Array)
+    val uint8Array = new Uint8Array(4)
+    setDEADBEEF(uint8Array)
+    val byteVector: ByteVector = ByteVector.fromUint8Array(uint8Array)
     assert(byteVector === hex"deadbeef")
-    int8Array(3) = 0xEE.toByte
+    uint8Array(3) = 0xee.toByte
     assert(byteVector === hex"deadbeef")
   }
 
   test("fromArrayBuffer") {
     val arrayBuffer = new ArrayBuffer(4)
-    val int8Array = new Int8Array(arrayBuffer)
-    setDEADBEEF(int8Array)
-    val byteVector: ByteVector = ByteVector.fromArrayBuffer(arrayBuffer)
+    val uint8Array = new Uint8Array(arrayBuffer)
+    setDEADBEEF(uint8Array)
+    val byteVector: ByteVector = ByteVector.fromJSArrayBuffer(arrayBuffer)
     assert(byteVector === hex"deadbeef")
-    int8Array(3) = 0xEE.toByte
+    uint8Array(3) = 0xee.toByte
     assert(byteVector === hex"deadbeef")
   }
 
   test("copyToTypedArray") {
-    val int8Array = new Int8Array(6)
-    int8Array(0) = 0xAA.toByte
-    int8Array(5) = 0xFF.toByte
-    hex"bbccdeadbeefee".copyToTypedArray(int8Array, 1, 2, 4)
-    assert(ByteVector.view(int8Array) === hex"aadeadbeefff")
+    val uint8Array = new Uint8Array(6)
+    uint8Array(0) = 0xaa.toByte
+    uint8Array(5) = 0xff.toByte
+    hex"bbccdeadbeefee".copyToUint8Array(uint8Array, 1, 2, 4)
+    assert(ByteVector.view(uint8Array) === hex"aadeadbeefff")
   }
 
   test("toTypedArray") {
-    assert(ByteVector.view(hex"deadbeef".toTypedArray) === hex"deadbeef")
+    assert(ByteVector.view(hex"deadbeef".toUint8Array) === hex"deadbeef")
   }
 }


### PR DESCRIPTION
Every JS API I've worked with uses `Uint8Array` type to represent byte vectors, which I'm guessing is how these conversions will be used 99% of the time. Also adjusted method names to avoid ambiguity.