### PR TITLE
read() in inputstream should return unsigned value

### DIFF
--- a/core/shared/src/main/scala/scodec/bits/ByteVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/ByteVector.scala
@@ -2262,7 +2262,8 @@ object ByteVector extends ByteVectorCompanionCrossPlatform {
     private val bvlen = bv.size.toInt
     private val pos = new CustomAtomicInteger(0)
 
-    override def read(): Int = bv.get(pos.getAndIncrement().toLong)
+    override def read(): Int =
+      if (pos.get() >= bvlen) -1 else bv.get(pos.getAndIncrement().toLong) & 0xff
 
     override def read(b: Array[Byte], off: Int, len: Int): Int = {
       var l: Int = -1

--- a/core/shared/src/main/scala/scodec/bits/ByteVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/ByteVector.scala
@@ -2262,8 +2262,10 @@ object ByteVector extends ByteVectorCompanionCrossPlatform {
     private val bvlen = bv.size.toInt
     private val pos = new CustomAtomicInteger(0)
 
-    override def read(): Int =
-      if (pos.get() >= bvlen) -1 else bv.get(pos.getAndIncrement().toLong) & 0xff
+    override def read(): Int = {
+      val p = pos.getAndIncrement()
+      if (p >= bvlen) -1 else bv.get(p.toLong) & 0xff
+    }
 
     override def read(b: Array[Byte], off: Int, len: Int): Int = {
       var l: Int = -1
@@ -2283,7 +2285,7 @@ object ByteVector extends ByteVectorCompanionCrossPlatform {
       l
     }
 
-    override def available(): Int = bvlen - pos.get()
+    override def available(): Int = Math.max(bvlen - pos.get(), 0)
 
     /* This is quite a hack. The problem is that the code has to be Scala-agnostic but Scala.js implementation of `AtomicInteger` differs
      * from the JVM standard one and it doesn't contain `getAndUpdate` method. So I took the method and put here the code with a different name

--- a/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
@@ -763,13 +763,13 @@ class ByteVectorTest extends BitsSuite {
     {
       val is = ByteVector(0, 1, 2).toInputStream
       assert(is.available() == 3)
-      assert(is.read == 0)
+      assert(is.read() == 0)
       assert(is.available() == 2)
-      assert(is.read == 1)
+      assert(is.read() == 1)
       assert(is.available() == 1)
-      assert(is.read == 2)
+      assert(is.read() == 2)
       assert(is.available() == 0)
-      assert(is.read == -1)
+      assert(is.read() == -1)
       assert(is.available() == 0)
     }
   }

--- a/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
@@ -760,5 +760,17 @@ class ByteVectorTest extends BitsSuite {
       assert(is.read(a) == -1)
       assert(is.available() == 0)
     }
+    {
+      val is = ByteVector(0, 1, 2).toInputStream
+      assert(is.available() == 3)
+      assert(is.read == 0)
+      assert(is.available() == 2)
+      assert(is.read == 1)
+      assert(is.available() == 1)
+      assert(is.read == 2)
+      assert(is.available() == 0)
+      assert(is.read == -1)
+      assert(is.available() == 0)
+    }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/scodec/scodec-bits/issues/369

`read()` should return a value between 0 and 255 (https://docs.oracle.com/javase/9/docs/api/java/io/InputStream.html#read--)