### PR TITLE
Support streaming hex dumps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,10 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ProblemFilters.exclude[DirectMissingMethodProblem]("scodec.bits.crc.vectorTable"),
   ProblemFilters.exclude[IncompatibleMethTypeProblem](
     "scodec.bits.ByteVector#ByteVectorInputStream#CustomAtomicInteger.getAndUpdate_"
-  )
+  ),
+  ProblemFilters.exclude[IncompatibleMethTypeProblem]("scodec.bits.HexDumpFormat.render"),
+  ProblemFilters.exclude[IncompatibleMethTypeProblem]("scodec.bits.HexDumpFormat.print"),
+  ProblemFilters.exclude[DirectMissingMethodProblem]("scodec.bits.HexDumpFormat.this")
 )
 
 lazy val root = tlCrossRootProject.aggregate(core, benchmark)


### PR DESCRIPTION
This PR re-implements hex dumps to allow for constant memory streaming of suspended `BitVector`s. It uses the same technique as `StreamingBitVectorTest`, where care is taken to ensure we don't hold on to a `BitVector` that later is forced by iteration.