### PR TITLE
Add ascii and utf8 interpolators

### DIFF
--- a/core/shared/src/main/scala-2/scodec/bits/package.scala
+++ b/core/shared/src/main/scala-2/scodec/bits/package.scala
@@ -73,7 +73,7 @@ package object bits extends ScalaVersionSpecific {
       *
       * Named arguments are supported in the same manner as the standard `s` interpolator.
       */
-    def ascii(args: String*): ByteVector = macro LiteralSyntaxMacros.asciiStringInterpolator
+    def asciiBytes(args: String*): ByteVector = macro LiteralSyntaxMacros.asciiStringInterpolator
   }
 
   /** Provides the `utf8` string interpolator, which returns `ByteVector` instances from UTF8
@@ -85,7 +85,7 @@ package object bits extends ScalaVersionSpecific {
       *
       * Named arguments are supported in the same manner as the standard `s` interpolator.
       */
-    def utf8(args: String*): ByteVector = macro LiteralSyntaxMacros.utf8StringInterpolator
+    def utf8Bytes(args: String*): ByteVector = macro LiteralSyntaxMacros.utf8StringInterpolator
   }
 
   private[bits] implicit class EitherOps[L, R](val self: Either[L, R]) extends AnyVal {

--- a/core/shared/src/main/scala-2/scodec/bits/package.scala
+++ b/core/shared/src/main/scala-2/scodec/bits/package.scala
@@ -64,6 +64,30 @@ package object bits extends ScalaVersionSpecific {
     def hex(args: ByteVector*): ByteVector = macro LiteralSyntaxMacros.hexStringInterpolator
   }
 
+  /** Provides the `ascii` string interpolator, which returns `ByteVector` instances from ascii
+    * strings.
+    */
+  final implicit class AsciiStringSyntax(val sc: StringContext) extends AnyVal {
+
+    /** Converts this ascii literal string to a `ByteVector`.
+      *
+      * Named arguments are supported in the same manner as the standard `s` interpolator.
+      */
+    def ascii(args: String*): ByteVector = macro LiteralSyntaxMacros.asciiStringInterpolator
+  }
+
+  /** Provides the `utf8` string interpolator, which returns `ByteVector` instances from UTF8
+    * strings.
+    */
+  final implicit class Utf8StringSyntax(val sc: StringContext) extends AnyVal {
+
+    /** Converts this UTF8 literal string to a `ByteVector`.
+      *
+      * Named arguments are supported in the same manner as the standard `s` interpolator.
+      */
+    def utf8(args: String*): ByteVector = macro LiteralSyntaxMacros.utf8StringInterpolator
+  }
+
   private[bits] implicit class EitherOps[L, R](val self: Either[L, R]) extends AnyVal {
     def map[R2](f: R => R2): Either[L, R2] =
       self match {

--- a/core/shared/src/main/scala-3/scodec/bits/Interpolators.scala
+++ b/core/shared/src/main/scala-3/scodec/bits/Interpolators.scala
@@ -62,7 +62,7 @@ extension (inline ctx: StringContext)
   * }}}
   */
 extension (inline ctx: StringContext)
-  inline def ascii(inline args: Any*): ByteVector =
+  inline def asciiBytes(inline args: Any*): ByteVector =
     ${ Literals.Ascii('ctx, 'args) }
 
 /** Provides the `utf8` string interpolator, which returns `ByteVector` instances from utf8 strings.
@@ -73,7 +73,7 @@ extension (inline ctx: StringContext)
   * }}}
   */
 extension (inline ctx: StringContext)
-  inline def utf8(inline args: Any*): ByteVector =
+  inline def utf8Bytes(inline args: Any*): ByteVector =
     ${ Literals.Utf8('ctx, 'args) }
 
 object Literals:

--- a/core/shared/src/main/scala-3/scodec/bits/Interpolators.scala
+++ b/core/shared/src/main/scala-3/scodec/bits/Interpolators.scala
@@ -116,11 +116,11 @@ object Literals:
   object Ascii extends Validator[ByteVector]:
     def validate(s: String)(using Quotes): Either[String, Expr[ByteVector]] =
       ByteVector.encodeAscii(s) match
-        case Left(ex)    => Left(s"ascii string literal may only contain valid ascii: $ex")
+        case Left(ex) => Left(s"ascii string literal may only contain valid ascii: $ex")
         case Right(_) => Right('{ ByteVector.encodeAscii(${ Expr(s) }).fold(throw _, identity) })
 
   object Utf8 extends Validator[ByteVector]:
     def validate(s: String)(using Quotes): Either[String, Expr[ByteVector]] =
       ByteVector.encodeUtf8(s) match
-        case Left(ex)    => Left(s"UTF8 string literal may only contain valid UTF8: $ex")
+        case Left(ex) => Left(s"UTF8 string literal may only contain valid UTF8: $ex")
         case Right(_) => Right('{ ByteVector.encodeUtf8(${ Expr(s) }).fold(throw _, identity) })

--- a/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
@@ -773,4 +773,13 @@ class ByteVectorTest extends BitsSuite {
       assert(is.available() == 0)
     }
   }
+
+  test("ascii interpolator") {
+    assertEquals(ascii"deadbeef", ByteVector.encodeAscii(s"deadbeef").toOption.get)
+    assert(compileErrors("""ascii"ɟǝǝqpɐǝp"""").contains("error"))
+  }
+
+  test("utf8 interpolator") {
+    assertEquals(utf8"ɟǝǝqpɐǝp", ByteVector.encodeUtf8(s"ɟǝǝqpɐǝp").toOption.get)
+  }
 }

--- a/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
@@ -775,11 +775,11 @@ class ByteVectorTest extends BitsSuite {
   }
 
   test("ascii interpolator") {
-    assertEquals(ascii"deadbeef", ByteVector.encodeAscii(s"deadbeef").toOption.get)
-    assert(compileErrors("""ascii"ɟǝǝqpɐǝp"""").contains("error"))
+    assertEquals(asciiBytes"deadbeef", ByteVector.encodeAscii(s"deadbeef").toOption.get)
+    assert(compileErrors("""asciiBytes"ɟǝǝqpɐǝp"""").contains("error"))
   }
 
   test("utf8 interpolator") {
-    assertEquals(utf8"ɟǝǝqpɐǝp", ByteVector.encodeUtf8(s"ɟǝǝqpɐǝp").toOption.get)
+    assertEquals(utf8Bytes"ɟǝǝqpɐǝp", ByteVector.encodeUtf8(s"ɟǝǝqpɐǝp").toOption.get)
   }
 }


### PR DESCRIPTION
Wanted these at least a few times :)

```
scala> val b = ascii"deadbeef"
val b: scodec.bits.ByteVector = ByteVector(8 bytes, 0x6465616462656566)
 ```

```
scala> val b = utf8"ɟǝǝqpɐǝp"
val b: scodec.bits.ByteVector = ByteVector(13 bytes, 0xc99fc79dc79d7170c990c79d70)
```