### PR TITLE
Add ByteVector#toArrayUnsafe - a zero-copy version of toArray

### DIFF
--- a/core/shared/src/main/scala/scodec/bits/ByteVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/ByteVector.scala
@@ -613,6 +613,17 @@ sealed abstract class ByteVector
     buf
   }
 
+  /** Zero-copy version of [[toArray]]. In the case where this vector is a simple wrapper
+    * around an underlying array, the array is returned directly instead of copying it.
+    * In all other cases, a copy is returned.
+    *
+    * @group conversions
+    */
+  final def toArrayUnsafe: Array[Byte] = this match {
+    case Chunk(v) => v.toArrayUnsafe
+    case _        => toArray
+  }
+
   /** Copies the contents of this vector to array `xs`, beginning at index `start`.
     *
     * @group conversions

--- a/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
@@ -439,6 +439,12 @@ class ByteVectorTest extends BitsSuite {
     }
   }
 
+  test("toArrayUnsafe") {
+    val arr = "Hello, world!".getBytes
+    assert(arr eq ByteVector.view(arr).toArrayUnsafe)
+    assert(arr ne ByteVector.view(arr).drop(1).toArrayUnsafe)
+  }
+
   property("copyToStream roundtrip") {
     forAll { (b: ByteVector) =>
       val os = new ByteArrayOutputStream()


### PR DESCRIPTION
Fixes #109 