### PR TITLE
Optimize toHex

### DIFF
--- a/benchmark/src/main/scala/ByteVectorBenchmark.scala
+++ b/benchmark/src/main/scala/ByteVectorBenchmark.scala
@@ -1,3 +1,33 @@
+/*
+ * Copyright (c) 2013, Scodec
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package scodec.bits
 
 import org.openjdk.jmh.annotations._
@@ -21,12 +51,10 @@ class ByteVectorBenchmark {
   }
 
   @Setup(Level.Trial)
-  def setup(): Unit = {
+  def setup(): Unit =
     bv = ByteVector.view(bytes)
-  }
 
   @Benchmark
   def encodeHex: String =
     bv.toHex
 }
-

--- a/benchmark/src/main/scala/ByteVectorBenchmark.scala
+++ b/benchmark/src/main/scala/ByteVectorBenchmark.scala
@@ -1,0 +1,32 @@
+package scodec.bits
+
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+class ByteVectorBenchmark {
+  @Param(Array("1000", "10000", "100000"))
+  var size: Int = _
+
+  private var bv: ByteVector = _
+
+  def bytes: Array[Byte] = {
+    val r = new scala.util.Random(size)
+    val bs = new Array[Byte](size * 3)
+    r.nextBytes(bs)
+    bs
+  }
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    bv = ByteVector.view(bytes)
+  }
+
+  @Benchmark
+  def encodeHex: String =
+    bv.toHex
+}
+

--- a/core/shared/src/main/scala/scodec/bits/ByteVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/ByteVector.scala
@@ -806,14 +806,23 @@ sealed abstract class ByteVector
   final def toHex(alphabet: Bases.HexAlphabet): String = {
     val out = new Array[Char](size.toInt * 2)
     var i = 0
-    foreachS {
-      new F1BU {
-        def apply(b: Byte) = {
-          out(i) = alphabet.toChar(b >> 4 & 0x0f)
-          out(i + 1) = alphabet.toChar(b & 0x0f)
-          i += 2
+    def update(b: Byte): Unit = {
+      out(i) = alphabet.toChar(b >> 4 & 0x0f)
+      out(i + 1) = alphabet.toChar(b & 0x0f)
+      i += 2
+    }
+    foreachV {
+      case View(atArr: AtArray, offset, length) =>
+        var j = offset
+        val end = offset + length
+        while (j < end) {
+          update(atArr(j))
+          j += 1
         }
-      }
+      case other =>
+        other.foreach(new F1BU {
+          def apply(b: Byte) = update(b)
+        })
     }
     new String(out)
   }

--- a/core/shared/src/main/scala/scodec/bits/ByteVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/ByteVector.scala
@@ -804,18 +804,18 @@ sealed abstract class ByteVector
     * @group conversions
     */
   final def toHex(alphabet: Bases.HexAlphabet): String = {
-    val bldr = new StringBuilder
+    val out = new Array[Char](size.toInt * 2)
+    var i = 0
     foreachS {
       new F1BU {
         def apply(b: Byte) = {
-          bldr
-            .append(alphabet.toChar((b >> 4 & 0x0f).toByte.toInt))
-            .append(alphabet.toChar((b & 0x0f).toByte.toInt))
-          ()
+          out(i) = alphabet.toChar(b >> 4 & 0x0f)
+          out(i + 1) = alphabet.toChar(b & 0x0f)
+          i += 2
         }
       }
     }
-    bldr.toString
+    new String(out)
   }
 
   /** Generates a hex dump of this vector using the default format (with no color / ANSI escapes).

--- a/core/shared/src/main/scala/scodec/bits/ByteVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/ByteVector.scala
@@ -819,6 +819,12 @@ sealed abstract class ByteVector
           update(atArr(j))
           j += 1
         }
+      case View(atByteBuffer: AtByteBuffer, offset, length) =>
+        val buf = atByteBuffer.buf.duplicate()
+        buf.position(offset.toInt)
+        buf.limit((offset + length).toInt)
+        while (buf.hasRemaining())
+          update(buf.get())
       case other =>
         other.foreach(new F1BU {
           def apply(b: Byte) = update(b)

--- a/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
@@ -186,6 +186,10 @@ class ByteVectorTest extends BitsSuite {
     )
   }
 
+  property("toHex fromHex roundtrip") {
+    forAll((b: ByteVector) => ByteVector.fromHex(b.toHex).get == b)
+  }
+
   test("toBin") {
     assert(deadbeef.toBin == "11011110101011011011111011101111")
   }


### PR DESCRIPTION
- Remove use of StringBuilder
- Add a special case for arrays

These changes result in a ~4x improvement on array backed byte vectors and should have no penalty for non-array vectors.