### PR TITLE
`toByteBuffer` optimizations

### DIFF
--- a/core/shared/src/main/scala/scodec/bits/ByteVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/ByteVector.scala
@@ -755,15 +755,16 @@ sealed abstract class ByteVector
 
   /** Represents the contents of this vector as a read-only `java.nio.ByteBuffer`.
     *
-    * The returned buffer is read-only with limit set to the minimum number of bytes needed to
+    * The returned buffer has limit set to the minimum number of bytes needed to
     * represent the contents of this vector, position set to zero, and remaining set to the limit.
+    * It is read-only when it is backed by the same array as this vector i.e. it was created without copying.
     *
     * @group conversions
     */
   final def toByteBuffer: ByteBuffer =
     this match {
       case Chunk(v) => v.asByteBuffer
-      case _        => ByteBuffer.wrap(toArray).asReadOnlyBuffer()
+      case _        => ByteBuffer.wrap(toArray)
     }
 
   /** Converts the contents of this byte vector to a binary string of `size * 8` digits.
@@ -1377,7 +1378,7 @@ object ByteVector extends ByteVectorCompanionCrossPlatform {
     def asByteBuffer(offset: Long, size: Int): ByteBuffer = {
       val arr = new Array[Byte](size)
       copyToArray(arr, 0, offset, size)
-      ByteBuffer.wrap(arr).asReadOnlyBuffer()
+      ByteBuffer.wrap(arr)
     }
     def copyToArray(xs: Array[Byte], start: Int, offset: Long, size: Int): Unit = {
       var i = 0
@@ -1406,7 +1407,7 @@ object ByteVector extends ByteVectorCompanionCrossPlatform {
   private object AtEmpty extends At {
     def apply(i: Long) = throw new IllegalArgumentException("empty view")
     override def asByteBuffer(start: Long, size: Int): ByteBuffer =
-      ByteBuffer.allocate(0).asReadOnlyBuffer()
+      ByteBuffer.allocate(0)
     override def copyToBuffer(buffer: ByteBuffer, offset: Long, size: Int): Int = 0
   }
 

--- a/core/shared/src/main/scala/scodec/bits/ByteVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/ByteVector.scala
@@ -1493,7 +1493,12 @@ object ByteVector extends ByteVectorCompanionCrossPlatform {
     def toArrayUnsafe: Array[Byte] =
       at match {
         case atarr: AtArray if offset == 0 && size == atarr.arr.size => atarr.arr
-        case _                                                       => toArray
+        case atbuf: AtByteBuffer if {
+              val buf = atbuf.buf
+              buf.hasArray && offset == 0 && buf.arrayOffset == 0 && size == buf.array.length
+            } =>
+          atbuf.buf.array
+        case _ => toArray
       }
     def copyToBuffer(buffer: ByteBuffer): Int =
       at.copyToBuffer(buffer, offset, toIntSize(size))

--- a/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
@@ -469,6 +469,14 @@ class ByteVectorTest extends BitsSuite {
     }
   }
 
+  test("toByteBuffer is read-only when appropriate") {
+    val arr = "Hello, world!".getBytes
+    val bv = ByteVector.view(arr)
+    assert(bv.toByteBuffer.isReadOnly)
+    assert(bv.drop(1).toByteBuffer.isReadOnly)
+    assert(!(bv ++ bv).toByteBuffer.isReadOnly)
+  }
+
   property("dropping from a view is consistent with dropping from a strict vector") {
     forAll { (b: ByteVector, n0: Long) =>
       val view = ByteVector.view(b.toArray)

--- a/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
@@ -449,6 +449,8 @@ class ByteVectorTest extends BitsSuite {
     val arr = "Hello, world!".getBytes
     assert(arr eq ByteVector.view(arr).toArrayUnsafe)
     assert(arr ne ByteVector.view(arr).drop(1).toArrayUnsafe)
+    assert(arr eq ByteVector.view(ByteBuffer.wrap(arr)).toArrayUnsafe)
+    assert(arr ne ByteVector.view(ByteBuffer.wrap(arr)).drop(1).toArrayUnsafe)
   }
 
   property("copyToStream roundtrip") {

--- a/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
@@ -479,6 +479,14 @@ class ByteVectorTest extends BitsSuite {
     assert(!(bv ++ bv).toByteBuffer.isReadOnly)
   }
 
+  test("toByteBufferUnsafe") {
+    val arr = "Hello, world!".getBytes
+    assert(arr eq ByteVector.view(arr).toByteBufferUnsafe.array)
+    assert(arr eq ByteVector.view(arr).drop(1).toByteBufferUnsafe.array)
+    assert(arr eq ByteVector.view(ByteBuffer.wrap(arr)).toByteBufferUnsafe.array)
+    assert(arr eq ByteVector.view(ByteBuffer.wrap(arr)).drop(1).toByteBufferUnsafe.array)
+  }
+
   property("dropping from a view is consistent with dropping from a strict vector") {
     forAll { (b: ByteVector, n0: Long) =>
       val view = ByteVector.view(b.toArray)


### PR DESCRIPTION
1. `toByteBuffer` should only return a read-only buffer if necessary to protect its internals. Read-only buffers don't allow access to the underlying array which can force further copies downstream. If the data is already being copied, then there is no reason to return a read-only buffer.

2. Add `toByteBufferUnsafe`. In the spirit of `toArrayUnsafe`, but can avoid copies in several more situations e.g. a view of a slice of an array. This will enable copy-free transforms to `Chunk.ArraySlice` in FS2.