### PR TITLE
Duplicate buffer in `asByteBufferUnsafe`

### DIFF
--- a/core/shared/src/main/scala/scodec/bits/ByteVector.scala
+++ b/core/shared/src/main/scala/scodec/bits/ByteVector.scala
@@ -1464,7 +1464,7 @@ object ByteVector extends ByteVectorCompanionCrossPlatform {
       asByteBufferUnsafe(offset, size).asReadOnlyBuffer()
 
     override def asByteBufferUnsafe(offset: Long, size: Int): ByteBuffer = {
-      val b = buf
+      val b = buf.duplicate()
       if (offset == 0 && b.position() == 0 && size == b.remaining()) b
       else {
         b.position(offset.toInt)

--- a/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
+++ b/core/shared/src/test/scala/scodec/bits/ByteVectorTest.scala
@@ -487,6 +487,18 @@ class ByteVectorTest extends BitsSuite {
     assert(arr eq ByteVector.view(ByteBuffer.wrap(arr)).drop(1).toByteBufferUnsafe.array)
   }
 
+  test("toByteBufferUnsafe has independent position+limit") {
+    val bv = ByteVector.view(ByteBuffer.wrap("Hello, world!".getBytes))
+    val bb1 = bv.toByteBufferUnsafe
+    assertEquals(bb1.position(), 0)
+    assertEquals(bb1.limit(), 13)
+    val bb2 = bv.toByteBufferUnsafe
+    bb2.position(1)
+    bb2.limit(2)
+    assertEquals(bb1.position(), 0)
+    assertEquals(bb1.limit(), 13)
+  }
+
   property("dropping from a view is consistent with dropping from a strict vector") {
     forAll { (b: ByteVector, n0: Long) =>
       val view = ByteVector.view(b.toArray)


### PR DESCRIPTION
So that its position / limit are independent.

https://github.com/scodec/scodec-bits/blob/0b7a1aff2e52c875aceaf28c481ae12723e55fba/core/shared/src/main/scala/scodec/bits/ByteVector.scala#L770-L776